### PR TITLE
BUG FIX: Billing info fields hidden for check GW

### DIFF
--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -269,7 +269,7 @@ function pmprodon_pmpro_checkout_after_level_cost()
 			jQuery('#pmpro_payment_information_fields').show();
 			pmpro_require_billing = true;
 		}
-		else
+		else if ( 'check' !== gateway )
 		{
 			jQuery('#pmpro_billing_address_fields').hide();
 			jQuery('#pmpro_payment_information_fields').hide();


### PR DESCRIPTION
Quick and dirty fix for when using the Pay By Check add-on and selecting to pay by check. The toggle of the "Pay By Check" option without any donations specified - on the checkout page - would hide the billing information fields (which doesn't work for either add-on).