### PR TITLE
Resolved issue where "Other" would always be shwon in donation dropdown

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -87,8 +87,10 @@ function pmprodon_pmpro_checkout_after_level_cost() {
 				<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo pmpro_formatPrice( (double) $price ); ?></option>
 				<?php
 			}
-			?>
-			<option value="other" <?php selected( true, ! empty( $donation ) && ! in_array( $donation, $dropdown_prices ) ); ?>>Other</option>
+			if ( $pmprodon_allow_other ) {
+				?>
+				<option value="other" <?php selected( true, ! empty( $donation ) && ! in_array( $donation, $dropdown_prices ) ); ?>>Other</option>
+			<?php } ?>
 		</select> &nbsp;
 		<?php
 	}


### PR DESCRIPTION
To re-create this issue, create a level with list of donation amounts that doesn't contain `other`. When you view the checkout page, `Other` will still be included as a donation amount.

Interesting note, on a user's site that was using the old code, the `Other` option was being hidden in Google Chrome browser, but not Safari, though I couldn't replicate this particular behavior on a testing site.