### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -240,8 +240,8 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 		// was a donation passed in?
 		if ( isset( $_REQUEST['donation'] ) ) {
 			// get values
-			$level_id  = intval( $_REQUEST['level'] );
-			$donfields = get_option( 'pmprodon_' . $level_id );
+			$level = pmpro_getLevelAtCheckout();
+			$donfields = get_option( 'pmprodon_' . $level->id );
 
 			// make sure this level has variable pricing
 			if ( empty( $donfields ) || empty( $donfields['donations'] ) ) {
@@ -390,11 +390,10 @@ add_action( 'pmpro_paypalexpress_session_vars', 'pmprodon_pmpro_paypalexpress_se
 function pmprodon_pmpro_checkout_preheader() {
 	global $besecure;
 
-	if ( ! is_admin() && ! empty( $_REQUEST['level'] ) ) {
-		$level_id = intval( $_REQUEST['level'] );
-
+	$level = pmpro_getLevelAtCheckout();
+	if ( ! is_admin() && ! empty( $level->id ) ) {
 		$donfields = get_option(
-			'pmprodon_' . $level_id, array(
+			'pmprodon_' . intval( $level->id ), array(
 				'donations'       => 0,
 				'min_price'       => '',
 				'max_price'       => '',


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.