### PR TITLE
Add delimiters to regular expressions in checkout.php

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -49,9 +49,9 @@ function pmprodon_pmpro_checkout_after_level_cost() {
 	$dropdown_prices = $donfields['dropdown_prices'];
 
 	if ( isset( $_REQUEST['donation'] ) ) {
-		$donation = preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );
+		$donation = preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] );
 	} elseif ( isset( $_SESSION['donation'] ) ) {
-		$donation = preg_replace( '[^0-9\.]', '', $_SESSION['donation'] );
+		$donation = preg_replace( '/[^0-9\.]/', '', $_SESSION['donation'] );
 	} elseif ( ! empty( $min_price ) ) {
 		$donation = $min_price;
 	} else {
@@ -209,9 +209,9 @@ add_action( 'pmpro_checkout_after_level_cost', 'pmprodon_pmpro_checkout_after_le
 function pmprodon_pmpro_checkout_level( $level ) {
 
 	if ( isset( $_REQUEST['donation'] ) ) {
-		$donation = preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );
+		$donation = preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] );
 	} elseif ( isset( $_SESSION['donation'] ) ) {
-		$donation = preg_replace( '[^0-9\.]', '', $_SESSION['donation'] );
+		$donation = preg_replace( '/[^0-9\.]/', '', $_SESSION['donation'] );
 	} else {
 		return $level;
 	}
@@ -250,7 +250,7 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 			}
 
 			// get price
-			$donation = preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );
+			$donation = preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] );
 
 			// check that the donation falls between the min and max
 			if ( (double) $donation < 0 || ( ! empty( $donfields['min_price'] ) && (double) $donation < (double) $donfields['min_price'] ) ) {
@@ -293,7 +293,7 @@ add_filter( 'pmpro_level_cost_text', 'pmprodon_pmpro_level_cost_text', 10, 2 );
  */
 function pmprodon_pmpro_checkout_order( $order ) {
 	if ( ! empty( $_REQUEST['donation'] ) ) {
-		$donation = preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );
+		$donation = preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] );
 	} else {
 		return $order;
 	}


### PR DESCRIPTION
`preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );`

and

`preg_replace( '[^0-9\.]', '', $_REQUEST['donation'] );`

doesn't do anything anymore. It might have something to do with upgrading to PHP8.

When something like "US$9" is entered into the donation field, it passes right through unchanged.

Adding delimiters gets it working again.