### PR TITLE
Fixing donation not being added to PPE

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -402,7 +402,7 @@ function pmprodon_pmpro_checkout_preheader() {
 add_action( 'pmpro_checkout_preheader', 'pmprodon_pmpro_checkout_preheader' );
 
 /**
- * Fix issue where incorrect donation amoount is charged when using PayPal Express.
+ * Fix issue where incorrect donation amount is charged when using PayPal Express.
  *
  * @since TBD
  */

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -400,3 +400,47 @@ function pmprodon_pmpro_checkout_preheader() {
 	}
 }
 add_action( 'pmpro_checkout_preheader', 'pmprodon_pmpro_checkout_preheader' );
+
+/**
+ * Fix issue where incorrect donation amoount is charged when using PayPal Express.
+ *
+ * @since TBD
+ */
+function pmprodon_ppe_add_donation_to_request() {
+	// Check if the "review" or "confirm" request variables are set.
+	if ( empty( $_REQUEST['review'] ) && empty( $_REQUEST['confirm'] ) ) {
+		return;
+	}
+
+	// Check if we have a PPE token that we are reviewing.
+	if ( empty( $_REQUEST['token'] ) ) {
+		return;
+	}
+	$token = sanitize_text_field( $_REQUEST['token'] );
+
+	// Make sure that the MemberOrder class is loaded.
+	if ( ! class_exists( 'MemberOrder' ) ) {
+		return;
+	}
+
+	// Check if we have an order with this token.
+	$order = new MemberOrder();
+	$order->getMemberOrderByPayPalToken( $token );
+	if ( empty( $order->id ) ) {
+		return;
+	}
+
+	// Make sure that this order is in token status.
+	if ( $order->status !== 'token' ) {
+		return;
+	}
+
+	// Get the donation information for this order.
+	$donation = pmprodon_get_price_components( $order );
+
+	// If there is a donation amount on the order but not yet in $_REQUEST, add it.
+	if ( ! empty( $donation['donation'] ) && empty( $_REQUEST['donation'] ) ) {
+		$_REQUEST['donation'] = $donation['donation'];
+	}
+}
+add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmprodon_ppe_add_donation_to_request' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In the last update, we stopped storing donation amounts in `$_SESSION`. This appeared to work ok (correct amount shown in PayPal Express checkout UI and in PMPro orders), but in reality, the donation amount was not actually being charged when you look at the completed transactions in PayPal. This is due to how our confirmation step works after a PayPal express session is completed.

This PR fixes that issue by pulling the donation amount that the user chose out of the PMPro order when performing the PPE confirmation step to ensure that we are "confirming" the correct amount (level cost + donation).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Set up Donations Add On
2. Set up PPE
3. Check out for level with donation via PPE
4. Look at completed transaction in PPE. See that before PR, amount without donation shows. With PR, correct amount shows.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
