### PR TITLE
Adding Donation Confirmation Text

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -40,6 +40,7 @@ function pmprodon_get_level_settings( $level_id ) {
 		'max_price'       => '',
 		'dropdown_prices' => '',
 		'text'            => '',
+		'confirmation_message' => '',
 	);
 	
 	if ( $level_id > 0 ) {
@@ -56,9 +57,17 @@ function pmprodon_get_level_settings( $level_id ) {
  */
 function pmprodon_is_donations_only( $level_id ) {
 	$settings = pmprodon_get_level_settings( $level_id );
-	if ( $settings['donations'] && $settings['donations_only'] ) {
-		return true;
-	} else {
-		return false;
-	}
+	return pmprodon_is_donations( $level_id ) && $settings['donations_only'];
+}
+
+/**
+ * Check if a level is a donations level
+ *
+ * @param int $level_id ID of the level to check.
+ * @return bool True if the level is a donations level, false otherwise.
+ * @since TBD
+ */
+function pmprodon_is_donations( $level_id ) {
+	$settings = pmprodon_get_level_settings( $level_id );
+	return $settings['donations'];
 }

--- a/includes/common.php
+++ b/includes/common.php
@@ -57,17 +57,5 @@ function pmprodon_get_level_settings( $level_id ) {
  */
 function pmprodon_is_donations_only( $level_id ) {
 	$settings = pmprodon_get_level_settings( $level_id );
-	return pmprodon_is_donations( $level_id ) && $settings['donations_only'];
-}
-
-/**
- * Check if a level is a donations level
- *
- * @param int $level_id ID of the level to check.
- * @return bool True if the level is a donations level, false otherwise.
- * @since TBD
- */
-function pmprodon_is_donations( $level_id ) {
-	$settings = pmprodon_get_level_settings( $level_id );
-	return $settings['donations'];
+	return $settings['donations'] && $settings['donations_only'];
 }

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -73,8 +73,6 @@ add_action( 'pmpro_membership_level_after_other_settings', 'pmprodon_pmpro_membe
  * Save level cost text when the level is saved/added
  */
 function pmprodon_pmpro_save_membership_level( $level_id ) {
-	global $allowedposttags;
-
 	if ( ! empty( $_REQUEST['donations'] ) ) {
 		$donations = 1;
 	} else {
@@ -87,8 +85,8 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 	}
 	$min_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
 	$max_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
-	$text	= wp_kses( wp_unslash( $_REQUEST['donations_text'] ), $allowedposttags );
-	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['confirmation_message'] ), $allowedposttags );
+	$text	= wp_kses_post( wp_unslash( $_REQUEST['donations_text'] ) );
+	$confirmation_message = wp_kses_post( wp_unslash( $_REQUEST['confirmation_message'] ) );
 	$dropdown_prices = $_REQUEST['dropdown_prices'];
 
 	update_option(

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -12,6 +12,8 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 	$max_price       = ( ! isset( $donfields['max_price'] ) ) ? '' : $donfields['max_price'];
 	$donations_text  = ( ! isset( $donfields['text'] ) ) ? '' : $donfields['text'];
 	$dropdown_prices = ( ! isset( $donfields['dropdown_prices'] ) ) ? '' : $donfields['dropdown_prices'];	
+	$confirmation_message  = ( ! isset( $donfields['confirmation_message'] ) ) ? '' : $donfields['confirmation_message'];
+
 ?>
 <h2 class="topborder"><?php _e( 'Donations', 'pmpro-donations' ); ?></h2>
 <p><?php _e( 'If donations are enabled, users will be able to set an additional donation amount at checkout. That price will be added to any initial payment you set on this level. You can set the minimum and maxium amount allowed for gifts for this level.', 'pmpro-donations' ); ?></p>
@@ -54,6 +56,13 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 			<br /><small><?php _e( 'If not blank, this text will override the default text generated to explain the range of donation values accepted.', 'pmpro-donations' ); ?></small>
 		</td>
 	</tr>
+	<tr>
+		<th scope="row" valign="top"><label for="confirmation_message"><?php _e( 'Confirmation text:', 'pmpro-donations' ); ?></label></th>
+		<td>
+			<?php wp_editor( $confirmation_message, 'confirmation_message', array( 'textarea_rows' => 5 ) ); ?>
+			<br /><small><?php _e( 'If not blank, this text will be rendered after regular confirmation text.', 'pmpro-donations' ); ?></small>
+		</td>
+	</tr>
 </tbody>
 </table>
 <?php
@@ -76,9 +85,10 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 	} else {
 		$donations_only = 0;
 	}
-	$min_price       = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
-	$max_price       = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
-	$text            = wp_kses( wp_unslash( $_REQUEST['donations_text'] ), $allowedposttags );
+	$min_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
+	$max_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
+	$text	= wp_kses( wp_unslash( $_REQUEST['donations_text'] ), $allowedposttags );
+	$confirmation_message = wp_kses( wp_unslash( $_REQUEST['confirmation_message'] ), $allowedposttags );
 	$dropdown_prices = $_REQUEST['dropdown_prices'];
 
 	update_option(
@@ -89,6 +99,7 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 			'max_price'       => $max_price,
 			'text'            => $text,
 			'dropdown_prices' => $dropdown_prices,
+			'confirmation_message' => $confirmation_message,
 		)
 	);
 }

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -3,7 +3,7 @@
  * Add Min Price and Max Price Fields on the edit levels page
  */
 function pmprodon_pmpro_membership_level_after_other_settings() {
-	global $pmpro_currency_symbol, $allowedposttags;
+	global $pmpro_currency_symbol;
 	$level_id = intval( $_REQUEST['edit'] );
 	$donfields       = pmprodon_get_level_settings( $level_id );			
 	$donations       = ( ! isset( $donfields['donations'] ) ) ? 0 : $donfields['donations'];
@@ -13,7 +13,6 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 	$donations_text  = ( ! isset( $donfields['text'] ) ) ? '' : $donfields['text'];
 	$dropdown_prices = ( ! isset( $donfields['dropdown_prices'] ) ) ? '' : $donfields['dropdown_prices'];	
 	$confirmation_message  = ( ! isset( $donfields['confirmation_message'] ) ) ? '' : $donfields['confirmation_message'];
-
 ?>
 <h2 class="topborder"><?php _e( 'Donations', 'pmpro-donations' ); ?></h2>
 <p><?php _e( 'If donations are enabled, users will be able to set an additional donation amount at checkout. That price will be added to any initial payment you set on this level. You can set the minimum and maxium amount allowed for gifts for this level.', 'pmpro-donations' ); ?></p>
@@ -59,7 +58,7 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 	<tr>
 		<th scope="row" valign="top"><label for="confirmation_message"><?php esc_html_e( 'Confirmation text:', 'pmpro-donations' ); ?></label></th>
 		<td>
-			<?php wp_editor( wp_kses( $confirmation_message,$allowedposttags ), 'confirmation_message', array( 'textarea_rows' => 5 ) ); ?>
+			<?php wp_editor( wp_kses_post( $confirmation_message ), 'confirmation_message', array( 'textarea_rows' => 5 ) ); ?>
 			<br /><small><?php esc_html_e( 'If not blank, this text will be rendered after regular confirmation text.', 'pmpro-donations' ); ?></small>
 		</td>
 	</tr>
@@ -83,11 +82,11 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 	} else {
 		$donations_only = 0;
 	}
-	$min_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
-	$max_price	= preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
-	$text	= wp_kses_post( wp_unslash( $_REQUEST['donations_text'] ) );
+	$min_price	          = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
+	$max_price	          = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
+	$text	              = wp_kses_post( wp_unslash( $_REQUEST['donations_text'] ) );
 	$confirmation_message = wp_kses_post( wp_unslash( $_REQUEST['confirmation_message'] ) );
-	$dropdown_prices = $_REQUEST['dropdown_prices'];
+	$dropdown_prices      = $_REQUEST['dropdown_prices'];
 
 	update_option(
 		'pmprodon_' . $level_id, array(

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -3,7 +3,7 @@
  * Add Min Price and Max Price Fields on the edit levels page
  */
 function pmprodon_pmpro_membership_level_after_other_settings() {
-	global $pmpro_currency_symbol;
+	global $pmpro_currency_symbol, $allowedposttags;
 	$level_id = intval( $_REQUEST['edit'] );
 	$donfields       = pmprodon_get_level_settings( $level_id );			
 	$donations       = ( ! isset( $donfields['donations'] ) ) ? 0 : $donfields['donations'];
@@ -57,10 +57,10 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 		</td>
 	</tr>
 	<tr>
-		<th scope="row" valign="top"><label for="confirmation_message"><?php _e( 'Confirmation text:', 'pmpro-donations' ); ?></label></th>
+		<th scope="row" valign="top"><label for="confirmation_message"><?php esc_html_e( 'Confirmation text:', 'pmpro-donations' ); ?></label></th>
 		<td>
-			<?php wp_editor( $confirmation_message, 'confirmation_message', array( 'textarea_rows' => 5 ) ); ?>
-			<br /><small><?php _e( 'If not blank, this text will be rendered after regular confirmation text.', 'pmpro-donations' ); ?></small>
+			<?php wp_editor( wp_kses( $confirmation_message,$allowedposttags ), 'confirmation_message', array( 'textarea_rows' => 5 ) ); ?>
+			<br /><small><?php esc_html_e( 'If not blank, this text will be rendered after regular confirmation text.', 'pmpro-donations' ); ?></small>
 		</td>
 	</tr>
 </tbody>

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -55,15 +55,18 @@ add_filter( 'plugin_row_meta', 'pmprodon_plugin_row_meta', 10, 2 );
  */
 function pmprodon_pmpro_confirmation_message($message, $invoice) {
 	$level_id = $_REQUEST['pmpro_level'];
-	//Bail if not a donation level
-	if( ! pmprodon_is_donations( $level_id )) {
+	$settings = pmprodon_get_level_settings( $level_id );
+	if( ! $settings['donations'] ) {
+		//Bail if not a donation level or donations are not enabled.
 		return $message;
 	}
 
-	$settings = pmprodon_get_level_settings( $level_id );
-
-	//add to message
-	$message .= "<p>" .  $settings['confirmation_message'] . "</p>";
+	$message_to_replace = '<p>' . wp_kses_post( $settings['confirmation_message'] ) . '</p>';
+	if( strpos( $message, '!!donation_message!!' ) ) {
+		$message = str_replace( '!!donation_message!!', $message_to_replace, $message );
+	} else {
+		$message .= $message_to_replace;
+	}
 
 	return $message;
 }

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -46,7 +46,7 @@ add_filter( 'plugin_row_meta', 'pmprodon_plugin_row_meta', 10, 2 );
 
 
 /**
- *  Function to add custom confirmation message.
+ * Function to add custom confirmation message.
  *
  * @param string $message The confirmation message.
  * @param object $invoice The MemberOrder object.
@@ -65,20 +65,23 @@ function pmprodon_pmpro_confirmation_message( $message, $invoice ) {
 		$level_id = $_REQUEST['level'];
 	//Bail if we can't find the level ID.
 	} else {
-		return $message;
+		// Remove !!donation_message!! so that it doesn't appear in the confirmation message.
+		return str_replace( '!!donation_message!!', '', $message );
 	}
 
 
 	$settings = pmprodon_get_level_settings( $level_id );
-	//Bail if not a donation level or donations are not enabled.
-	if( ! $settings['donations'] ) {
-		return $message;
+	//Bail if not a donation level or donations are not enabled or there is no confirmation message.
+	if( ! $settings['donations'] || empty( $settings['confirmation_message'] ) ) {
+		// Remove !!donation_message!! so that it doesn't appear in the confirmation message.
+		return str_replace( '!!donation_message!!', '', $message );
 	}
 
 	$components = pmprodon_get_price_components( $invoice );
 	//Bail if no donation amount.
-	if (  empty( $components['donation'] ) ) {
-		return $message;
+	if ( empty( $components['donation'] ) ) {
+		// Remove !!donation_message!! so that it doesn't appear in the confirmation message.
+		return str_replace( '!!donation_message!!', '', $message );
 	}
 
 	$message_to_replace = '<p>' . wp_kses_post( $settings['confirmation_message'] ) . '</p>';

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -49,12 +49,25 @@ add_filter( 'plugin_row_meta', 'pmprodon_plugin_row_meta', 10, 2 );
  *  Function to add custom confirmation message.
  *
  * @param string $message The confirmation message.
- * @param object $invoice The invoice object.
+ * @param object $invoice The MemberOrder object.
  * @return string $message The confirmation message.
  * @since TBD
  */
 function pmprodon_pmpro_confirmation_message($message, $invoice) {
-	$level_id = $_REQUEST['pmpro_level'];
+		//Get the level ID from the MemberOrder object.
+	if ( $invoice  ) {
+		$level_id = $invoice->membership_id;
+		//If for some reason we can't find the level ID, try to get it from the URL.
+	 } else if ( isset ( $_REQUEST['pmpro_level'] ) ) {
+		$level_id = $_REQUEST['pmpro_level'];
+		// Backwards compatibility for PMPro 2.x
+	 }  else if ( isset ( $_REQUEST['level'] ) ) { 
+		$level_id = $_REQUEST['level'];
+	 } else {
+		//Bail if we can't find the level ID.
+		return $message;
+	}
+
 	$settings = pmprodon_get_level_settings( $level_id );
 	if( ! $settings['donations'] ) {
 		//Bail if not a donation level or donations are not enabled.

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -53,24 +53,31 @@ add_filter( 'plugin_row_meta', 'pmprodon_plugin_row_meta', 10, 2 );
  * @return string $message The confirmation message.
  * @since TBD
  */
-function pmprodon_pmpro_confirmation_message($message, $invoice) {
-		//Get the level ID from the MemberOrder object.
-	if ( $invoice  ) {
+function pmprodon_pmpro_confirmation_message( $message, $invoice ) {
+	//Get the level ID from the MemberOrder object.
+	if ( $invoice ) {
 		$level_id = $invoice->membership_id;
-		//If for some reason we can't find the level ID, try to get it from the URL.
+	//If for some reason we can't find the level ID, try to get it from the URL.
 	 } else if ( isset ( $_REQUEST['pmpro_level'] ) ) {
 		$level_id = $_REQUEST['pmpro_level'];
-		// Backwards compatibility for PMPro 2.x
+	// Backwards compatibility for PMPro 2.x
 	 }  else if ( isset ( $_REQUEST['level'] ) ) { 
 		$level_id = $_REQUEST['level'];
-	 } else {
-		//Bail if we can't find the level ID.
+	//Bail if we can't find the level ID.
+	} else {
 		return $message;
 	}
 
+
 	$settings = pmprodon_get_level_settings( $level_id );
+	//Bail if not a donation level or donations are not enabled.
 	if( ! $settings['donations'] ) {
-		//Bail if not a donation level or donations are not enabled.
+		return $message;
+	}
+
+	$components = pmprodon_get_price_components( $invoice );
+	//Bail if no donation amount.
+	if (  empty( $components['donation'] ) ) {
 		return $message;
 	}
 
@@ -87,4 +94,4 @@ function pmprodon_pmpro_confirmation_message($message, $invoice) {
 /**
  * Function to add custom confirmation message.
  */
-add_filter('pmpro_confirmation_message', 'pmprodon_pmpro_confirmation_message', 10, 2);
+add_filter( 'pmpro_confirmation_message', 'pmprodon_pmpro_confirmation_message', 10, 2 );

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -42,3 +42,33 @@ function pmprodon_plugin_row_meta( $links, $file ) {
 	return $links;
 }
 add_filter( 'plugin_row_meta', 'pmprodon_plugin_row_meta', 10, 2 );
+
+
+
+/**
+ *  Function to add custom confirmation message.
+ *
+ * @param string $message The confirmation message.
+ * @param object $invoice The invoice object.
+ * @return string $message The confirmation message.
+ * @since TBD
+ */
+function pmprodon_pmpro_confirmation_message($message, $invoice) {
+	$level_id = $_REQUEST['pmpro_level'];
+	//Bail if not a donation level
+	if( ! pmprodon_is_donations( $level_id )) {
+		return $message;
+	}
+
+	$settings = pmprodon_get_level_settings( $level_id );
+
+	//add to message
+	$message .= "<p>" .  $settings['confirmation_message'] . "</p>";
+
+	return $message;
+}
+
+/**
+ * Function to add custom confirmation message.
+ */
+add_filter('pmpro_confirmation_message', 'pmprodon_pmpro_confirmation_message', 10, 2);


### PR DESCRIPTION
…confirmation page for donatios -

 * Add a donation sppecific setting on the level settings (RTE)
 * Hook into the confirmation message core filter and append text after core confirmation message.
 * Mminor tweak to bolean checks for is donation and is donation only functions

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<img width="1340" alt="image" src="https://github.com/strangerstudios/pmpro-donations/assets/1678457/c70aff51-df41-4495-b65c-d468bd62458a">
<img width="1000" alt="image" src="https://github.com/strangerstudios/pmpro-donations/assets/1678457/6367067f-fd42-4d3a-a054-917d49cfde55">


### How to test the changes in this Pull Request:

1. Pull changes
2. Go to level settings
3. Check is donations checkbox. 
4. Add a custom confirmation text
5. Checkout that level.
6. See that donations custom text appear below core confirmation message.
7. Uncheck donations checkbox.
8. Check that the text isn't rendered anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
