### PR TITLE
Make sure donations don’t get an expiry date if they don’t have a lev…

### DIFF
--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -58,20 +58,32 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 </table>
 
 <script type="text/javascript">
-	jQuery(document).ready(function($) {
+	jQuery(document).ready(function() {
 		//toggle expiration details when donations only checkbox is clicked
-		$('#donations_only').change(function() {
-			if($(this).is(':checked')) {
-				$expWarning  = $('#pmpro_expiration_warning').clone();
-				$expWarning.attr('id', 'pmpro_expiration_warning_donations_only');
-				$expWarning.find('p').text('<?php _e( 'Donation only levels do not expire', 'pmpro-donations' ); ?>');
-				$expWarning.insertAfter('#pmpro_expiration_warning');
-				$expWarning.show();
-			} else {
-				$('#pmpro_expiration_warning_donations_only').remove();
-			}
+		toggleDonationsOnly(jQuery('#donations_only'));
+
+		jQuery('#donations_only').on('change', function() {
+			toggleDonationsOnly(jQuery(this));
 		});
 	});
+
+	/**
+	 * Toggle expiration warning depending on whether donations only is checked.
+	 *
+	 * @param {jQuery} donOnlyCheckbox The checkbox for donations only.
+	 * @return {void}
+	 */
+	const toggleDonationsOnly = (donOnlyCheckbox) => {
+		if(donOnlyCheckbox.is(':checked')) {
+			$expWarning = jQuery('#pmpro_expiration_warning').clone();
+			$expWarning.attr('id', 'pmpro_expiration_warning_donations_only');
+			$expWarning.find('p').text('<?php _e( 'Members that donate will receive an expiration date. Are you sure you want this ?', 'pmpro-donations' ); ?>');
+			$expWarning.insertAfter('#pmpro_expiration_warning');
+			$expWarning.show();
+		} else {
+			jQuery('#pmpro_expiration_warning_donations_only').remove();
+		}
+	}
 </script>
 
 <?php

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -59,15 +59,17 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 
 <script type="text/javascript">
 	jQuery(document).ready(function($) {
-		$expDetails = $('#expiration-details');
-		//hide expiration details if donations only is checked when DOM's ready
-		if( $('#donations_only').is(':checked')) {
-			$expDetails.hide();
-		}
-
 		//toggle expiration details when donations only checkbox is clicked
 		$('#donations_only').change(function() {
-			$expDetails.toggle(! $(this).is(':checked')) 
+			if($(this).is(':checked')) {
+				$expWarning  = $('#pmpro_expiration_warning').clone();
+				$expWarning.attr('id', 'pmpro_expiration_warning_donations_only');
+				$expWarning.find('p').text('<?php _e( 'Donation only levels do not expire', 'pmpro-donations' ); ?>');
+				$expWarning.insertAfter('#pmpro_expiration_warning');
+				$expWarning.show();
+			} else {
+				$('#pmpro_expiration_warning_donations_only').remove();
+			}
 		});
 	});
 </script>
@@ -107,16 +109,5 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 			'dropdown_prices' => $dropdown_prices,
 		)
 	);
-
-	//Donations only level shouldn't expire.
-	if ( $donations_only ) {
-		$current_level = new PMPro_Membership_Level( $level_id );
-		if( $current_level->expiration_number || $current_level->expiration_period ) {
-			$current_level->expiration_number = 0;
-			$current_level->expiration_period = 0;
-			$current_level->save();
-		}
-	}
 }
-
 add_action( 'pmpro_save_membership_level', 'pmprodon_pmpro_save_membership_level' );

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -56,6 +56,22 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 	</tr>
 </tbody>
 </table>
+
+<script type="text/javascript">
+	jQuery(document).ready(function($) {
+		$expDetails = $('#expiration-details');
+		//hide expiration details if donations only is checked when DOM's ready
+		if( $('#donations_only').is(':checked')) {
+			$expDetails.hide();
+		}
+
+		//toggle expiration details when donations only checkbox is clicked
+		$('#donations_only').change(function() {
+			$expDetails.toggle(! $(this).is(':checked')) 
+		});
+	});
+</script>
+
 <?php
 }
 add_action( 'pmpro_membership_level_after_other_settings', 'pmprodon_pmpro_membership_level_after_other_settings' );
@@ -91,5 +107,16 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 			'dropdown_prices' => $dropdown_prices,
 		)
 	);
+
+	//Donations only level shouldn't expire.
+	if ( $donations_only ) {
+		$current_level = new PMPro_Membership_Level( $level_id );
+		if( $current_level->expiration_number || $current_level->expiration_period ) {
+			$current_level->expiration_number = 0;
+			$current_level->expiration_period = 0;
+			$current_level->save();
+		}
+	}
 }
+
 add_action( 'pmpro_save_membership_level', 'pmprodon_pmpro_save_membership_level' );


### PR DESCRIPTION

<img width="1540" alt="image" src="https://github.com/strangerstudios/pmpro-donations/assets/1678457/abbd1d05-ffde-48ff-89d1-d2670786a599">


* Add a warning if level is a donation only and also checked expiration

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. With this Add On enabled, to to level settings page.
2. Toggle donations only checkbox and observe expirations settings section hide and show accordingly.
3. Set an expiration date 
4. Make a donation only level
5. save and edit the level. Observe expiration checkbox is unchecked. Or check database


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
