### PR TITLE
Update order meta if donation is greater than 0

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -26,12 +26,12 @@ function pmprodon_get_price_components( $order ) {
 		$r['donation'] = $donation;
 		if ( $donation > 0 ) {
 			$r['price'] = $order->total - $donation;
-		}
 
-		// Save the donation amount to the order meta and remove it from the notes.
-		update_pmpro_membership_order_meta( $order->id, 'donation_amount', $donation );
-		$order->notes = preg_replace( '/' . __( 'Donation', 'pmpro-donations' ) . '\: ([0-9\.]+)/', '', $order->notes );
-		$order->saveOrder();
+            // Save the donation amount to the order meta and remove it from the notes.
+            update_pmpro_membership_order_meta( $order->id, 'donation_amount', $donation );
+            $order->notes = preg_replace( '/' . __( 'Donation', 'pmpro-donations' ) . '\: ([0-9\.]+)/', '', $order->notes );
+            $order->saveOrder();
+		}
 	}
 
 	// filter added .2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We're now only saving the donation amount if the donation amount is greater than 0. 

By saving it again even if the donation amount is 0 (which can be for the majority of a site's orders before installing the Donation Add On) results in Member Order Exports timing out and experiencing memory issues due to excessive resource use.

### How to test the changes in this Pull Request:

1. The initial problem was found when trying to export order lists
2. Navigate to Memberships > Orders and export your orders. I had tested this on a site with 900 orders and it exported without issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
