### PR TITLE
Change invoice_id to order_id

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -346,7 +346,7 @@ function pmprodon_pmpro_invoice_bullets_bottom( $order ) {
 add_filter( 'pmpro_invoice_bullets_bottom', 'pmprodon_pmpro_invoice_bullets_bottom' );
 
 function pmprodon_pmpro_email_data( $data, $email ) {
-	$order_id = empty( $email->data['invoice_id'] ) ? false : $email->data['invoice_id'];
+	$order_id = empty( $email->data['order_id'] ) ? false : $email->data['order_id'];
 	if ( ! empty( $order_id ) ) {
 		$order      = new MemberOrder( $order_id );
 		$components = pmprodon_get_price_components( $order );
@@ -370,7 +370,7 @@ function pmprodon_pmpro_email_filter( $email ) {
 	// only update confirmation emails which aren't using !!donation!! email variable
 	if ( strpos( $email->template, 'checkout' ) !== false && strpos( $email->body, '!!donation!!' ) === false ) {
 		// get the user_id from the email
-		$order_id = ( empty( $email->data ) || empty( $email->data['invoice_id'] ) ) ? false : $email->data['invoice_id'];
+		$order_id = ( empty( $email->data ) || empty( $email->data['order_id'] ) ) ? false : $email->data['order_id'];
 		if ( ! empty( $order_id ) ) {
 			$order      = new MemberOrder( $order_id );
 			$components = pmprodon_get_price_components( $order );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

All instances of invoice_id changed to order_id to match the change in PMPro 3.1

Without this change, !!donation!! variable in checkout emails show !!donation!! instead of the donation amount.

### How to test the changes in this Pull Request:

1. Put !!donation!! in checkout email template.
2. Upgrade to PMPro 3.1
3. Checkout emails show !!donation!!
4. Apply change
5. Checkout emails show donation amount.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

[BUG FIX] Resolves issue with !!donation!! variable not working with email templates in PMPro 3.1. WARNING: not backwards compatible with PMPRO 3.0.6 and earlier. Upgrade to PMPro 3.1 first.