### PR TITLE
Fixing class selectors for <select> dropdown

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -73,7 +73,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 								// show dropdown
 								sort( $dropdown_prices );
 								?>
-								<select id="donation_dropdown" name="donation_dropdown" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select' ) ); ?>" <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?> class="<?php echo esc_attr( pmpro_get_element_class( 'select pmpro_alter_price' ) ); ?>" >
+								<select id="donation_dropdown" name="donation_dropdown" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select pmpro_alter_price' ) ); ?>" <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?>>
 									<?php
 									foreach ( $dropdown_prices as $price ) {
 										?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed classes for the select dropdown that had duplicate class="" names and wasn't showing the pmpro_alter_price field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Fixed the class names added to the <select> dropdown for donation amounts.