### PR TITLE
Give original membership level back after donation

### DIFF
--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -1,5 +1,11 @@
 <?php
+/*
+	IDEA
 
+	* Add setting to edit level page to mark it as a "donation-only level".
+	* Don't cancel any old orders or subscriptions when checking out for a donation-only level.
+	* If an existing user checks out for a donation-only level, give them their old level back.
+*/
 /**
  * Set existing member flag before checkout.
  * Store user's previous levels and prevent cancellation when checking out for donation-only level.

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -1,21 +1,22 @@
 <?php
-/*
-	IDEA
-	* Add setting to edit level page to mark it as a "donation-only level".
-	* Don't cancel any old orders or subscriptions when checking out for a donation-only level.
-	* If an existing user checks out for a donation-only level, give them their old level back.
-*/
 
 /**
  * Set existing member flag before checkout.
+ * Store user's previous levels and prevent cancellation when checking out for donation-only level.
+ *
+ * @param int    $user_id The user ID.
+ * @param object $morder The membership order object.
  */
 function pmprodon_pmpro_checkout_before_change_membership_level( $user_id, $morder ) {
 	global $pmprodon_existing_member_flag, $pmpro_level;
 
-	if ( pmpro_hasMembershipLevel()
-	&& pmpro_is_checkout()
-	&& ! empty( $pmpro_level )
-	&& pmprodon_is_donations_only( $pmpro_level->id ) ) {
+	if ( pmpro_hasMembershipLevel() && pmpro_is_checkout() && ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
+		// Store the user's current level info before it gets changed.
+		$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+		if ( ! empty( $current_levels ) ) {
+			update_user_meta( $user_id, 'pmprodon_previous_levels', $current_levels );
+		}
+
 		add_filter( 'pmpro_cancel_previous_subscriptions', '__return_false' );
 		add_filter( 'pmpro_deactivate_old_levels', '__return_false' );
 		$pmprodon_existing_member_flag = true;
@@ -25,19 +26,94 @@ add_action( 'pmpro_checkout_before_change_membership_level', 'pmprodon_pmpro_che
 
 /**
  * Give existing users their old level back after checkout.
+ * Enhanced to properly handle level groups and restore the appropriate level.
+ *
+ * @param int $user_id The user ID.
  */
 function pmprodon_pmpro_after_checkout( $user_id ) {
 	global $wpdb, $pmprodon_existing_member_flag, $pmpro_level;
 
 	if ( isset( $pmprodon_existing_member_flag ) ) {
-		// Remove last row added to members_users table.
-		$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . esc_sql( $user_id ) . "' AND membership_id = '" . esc_sql( $pmpro_level->id ) . "' ORDER BY id DESC LIMIT 1";
-		$wpdb->query( $sqlQuery );
+		// Get user's current levels.
+		$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
 
-		// Reset user.
-		global $all_membership_levels;
-		unset( $all_membership_levels[ $user_id ] );
-		pmpro_set_current_user();
+		// Check if they now have a donation-only level.
+		$donation_level_id = null;
+		$has_donation_level = false;
+
+		foreach ( $current_levels as $level ) {
+			if ( pmprodon_is_donations_only( $level->id ) ) {
+				$donation_level_id = $level->id;
+				$has_donation_level = true;
+				break;
+			}
+		}
+
+		// If user has a donation-only level, restore their previous level
+		if ( $has_donation_level ) {
+			// Get their previous levels that we stored.
+			$previous_levels = get_user_meta( $user_id, 'pmprodon_previous_levels', true );
+
+			if ( ! empty( $previous_levels ) ) {
+				// Determine which level we should restore.
+				$level_to_restore = null;
+
+				// Find a level from the same group as the donation level.
+				// Get donation level's group if available.
+				$donation_group_id = null;
+				if ( function_exists( 'pmpro_get_group_id_for_level' ) ) {
+					$donation_group_id = pmpro_get_group_id_for_level( $donation_level_id );
+				}
+
+				if ( $donation_group_id ) {
+					// Find a previous level in the same group.
+					foreach ( $previous_levels as $prev_level ) {
+						$prev_level_group_id = pmpro_get_group_id_for_level( $prev_level->id );
+						if ( $prev_level_group_id === $donation_group_id ) {
+							$level_to_restore = $prev_level;
+							break;
+						}
+					}
+				}
+
+				// If no level found in the same group, use the first previous level.
+				if ( ! $level_to_restore && ! empty( $previous_levels ) ) {
+					$level_to_restore = $previous_levels[0];
+				}
+
+				if ( $level_to_restore ) {
+					// Cancel the donation-only level properly
+					pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
+
+					// Create a custom level array for restoration.
+					$custom_level = array(
+						'user_id'         => $user_id,
+						'membership_id'   => $level_to_restore->id,
+						'code_id'         => $level_to_restore->code_id,
+						'initial_payment' => $level_to_restore->initial_payment,
+						'billing_amount'  => $level_to_restore->billing_amount,
+						'cycle_number'    => $level_to_restore->cycle_number,
+						'cycle_period'    => $level_to_restore->cycle_period,
+						'billing_limit'   => $level_to_restore->billing_limit,
+						'trial_amount'    => $level_to_restore->trial_amount,
+						'trial_limit'     => $level_to_restore->trial_limit,
+						'startdate'       => $level_to_restore->startdate,
+						'enddate'         => $level_to_restore->enddate,
+					);
+
+					// Restore the original level.
+					pmpro_changeMembershipLevel( $custom_level, $user_id );
+
+					// Clean up stored data.
+					delete_user_meta( $user_id, 'pmprodon_previous_levels' );
+				}
+
+				// Reset user.
+				global $all_membership_levels;
+				unset( $all_membership_levels[ $user_id ] );
+				pmpro_set_current_user();
+			}
+		}
 	}
 }
 add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
@@ -47,8 +123,8 @@ add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
  *
  * @since 1.1.2
  *
- * @param bool $return
- * @param object $level
+ * @param bool   $return Whether the level is expiring soon.
+ * @param object $level The level object.
  * @return bool
  */
 function pmprodon_pmpro_is_level_expiring_soon( $return, $level ) {

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -141,3 +141,37 @@ function pmprodon_pmpro_is_level_expiring_soon( $return, $level ) {
 	return $return;
 }
 add_filter( 'pmpro_is_level_expiring_soon', 'pmprodon_pmpro_is_level_expiring_soon', 10, 2 );
+
+/**
+ * Filter the text that says a level will be removed at checkout.
+ * Only modifies the specific text about level removal during checkout.
+ *
+ * @since TBD
+ *
+ * @param string $translated_text The translated text.
+ * @param string $text The original text.
+ * @param string $domain The text domain.
+ * @return string The modified text.
+ */
+function pmprodon_filter_checkout_level_change_text( $translated_text, $text, $domain ) {
+	// Only proceed if we're on the checkout page.
+	if ( ! pmpro_is_checkout() ) {
+		return $translated_text;
+	}
+
+	// Target only the specific message about level removal.
+	if ( $domain === 'paid-memberships-pro' &&
+		$text === 'Your current membership level of %s will be removed when you complete your purchase.' ) {
+
+		global $pmpro_level;
+
+		// Check if this is a donation-only level.
+		if ( ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
+			// Return a different message for donation-only levels.
+			return '';
+		}
+	}
+
+	return $translated_text;
+}
+add_filter( 'gettext', 'pmprodon_filter_checkout_level_change_text', 10, 3 );


### PR DESCRIPTION
Give the original level back to the member after checkout for a donation-only level that is in a level group that allows having only one level in the group.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Prevent cancellation of the user's current subscription at the payment gateway when checking out for a donation-only level in a level group that only allows a user to be a member of one level in the level group.
- Store the user checking out's current level settings in meta for when we want to give them their level back.
- Remove checkout text that their current level will be removed.
- Give the user's original level back to the member after the donation checkout completed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #72.

### How to test the changes in this Pull Request:

1. Create a new user by checking out for a membership level in a level group that has multiple levels but allow a user to only have one level from that group. 
2. Return to the membership levels page logged in as the test user,  select the donations-only level.
3. Confirm that the text about removing their current level have been removed.
4. Complete checkout to make a donation.
5. Verify on the Memberships Account page that their original level and not the donation-only level is listed as an active membership level for the use
6. If their original level was a recurring payment level, navigate to the payment gateway dashboard, locate the customer and verify that their recurring subscription at the payment gateway is still active and intact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Give original membership back when checking out for a donation-only level.