### PR TITLE
Add donation amount to order meta for all gateways

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -469,7 +469,7 @@ function pmprodon_store_donation_amount_in_order_meta( $order ) {
 		update_pmpro_membership_order_meta( $order->id, 'donation_amount', sanitize_text_field( $_REQUEST['donation'] ) );
 	}
 }
-add_action( 'pmpro_added_order', 'pmprodon_store_donation_amount_in_order_meta', 10, 2 );
+add_action( 'pmpro_added_order', 'pmprodon_store_donation_amount_in_order_meta' );
 
 /**
  * Function to add the donation confirmation message to the confirmation page.

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -462,15 +462,14 @@ add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmprodon_p
  *
  * @since 2.0
  *
- * @param int   $user_id The user ID.
  * @param object The order object.
  */
-function pmprodon_store_donation_amount_in_order_meta( $user_id, $order ) {
+function pmprodon_store_donation_amount_in_order_meta( $order ) {
 	if ( isset( $_REQUEST['donation'] ) ) {
 		update_pmpro_membership_order_meta( $order->id, 'donation_amount', sanitize_text_field( $_REQUEST['donation'] ) );
 	}
 }
-add_action( 'pmpro_after_checkout', 'pmprodon_store_donation_amount_in_order_meta', 10, 2 );
+add_action( 'pmpro_added_order', 'pmprodon_store_donation_amount_in_order_meta', 10, 2 );
 
 /**
  * Function to add the donation confirmation message to the confirmation page.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Saving the donation amount when the order is added.

Resolves #86 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed an issue where donation amount would not be saved to the order.
