### PR TITLE
Resolve deprecation warnings on PHP 8.5+

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -77,7 +77,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 									<?php
 									foreach ( $dropdown_prices as $price ) {
 										?>
-										<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (double) $price ) ); ?></option>
+										<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (float) $price ) ); ?></option>
 										<?php
 									}
 									if ( $pmprodon_allow_other ) {
@@ -254,11 +254,11 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 			$donation = sanitize_text_field( preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] ) );
 
 			// check that the donation falls between the min and max
-			if ( (double) $donation < 0 || ( ! empty( $donfields['min_price'] ) && (double) $donation < (double) $donfields['min_price'] ) ) {
+			if ( (float) $donation < 0 || ( ! empty( $donfields['min_price'] ) && (float) $donation < (float) $donfields['min_price'] ) ) {
 				$pmpro_msg  = sprintf( __( 'The lowest accepted donation is %s. Please enter a new amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['min_price'] ) );
 				$pmpro_msgt = 'pmpro_error';
 				$continue   = false;
-			} elseif ( ! empty( $donfields['max_price'] ) && (double) $donation > (double) $donfields['max_price'] ) {
+			} elseif ( ! empty( $donfields['max_price'] ) && (float) $donation > (float) $donfields['max_price'] ) {
 				$pmpro_msg = sprintf( __( 'The highest accepted donation is %s. Please enter a new amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['max_price'] ) );
 
 				$pmpro_msgt = 'pmpro_error';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-donations/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-donations/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Cast names (boolean), (integer), (double), and (binary) have been [deprecated in PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php).

Updating (double) cast name to (float).

Resolves notice `Non-canonical cast (double) is deprecated, use the (float) cast instead`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed a PHP deprecation warning that may show on sites running PHP 8.5+.
