### PR TITLE
PMPro Donations v3.0 — bug fixes, enhancements, new features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,230 @@
+# PMPro Donations — Agent Instructions
+
+> Paid Memberships Pro add-on for accepting donations at checkout. This file is the primary instruction reference for any AI agent working in this repo.
+
+## What This Is
+
+PMPro Donations adds donation functionality to the Paid Memberships Pro checkout flow. Members can add a one-time donation on top of their membership fee, or donate without a membership via "donation-only" levels.
+
+- **Plugin Slug**: `pmpro-donations`
+- **Current Version**: 2.2
+- **Requires**: Paid Memberships Pro (core plugin)
+- **WordPress Tested Up To**: 6.8
+- **PHP**: 7.4+ (supports up to 8.5)
+- **Text Domain**: `pmpro-donations`
+- **License**: GPL-2.0+
+- **Repo**: https://github.com/strangerstudios/pmpro-donations
+
+## Repo Layout
+
+```
+pmpro-donations/
+├── pmpro-donations.php           # Main plugin file (bootstrap, includes, meta links)
+├── includes/
+│   ├── common.php                # Shared utilities (get settings, get price components)
+│   ├── checkout.php              # Checkout flow: form display, validation, price modification
+│   ├── donation-only-level.php   # Donation-only level logic (keep member's existing level)
+│   ├── level-settings.php        # Admin: level edit page donation settings UI
+│   └── admin.php                 # Admin: order editing, CSV export column
+├── languages/
+│   ├── pmpro-donations.pot       # Translation template
+│   ├── pmpro-donations.po        # Translation source
+│   ├── pmpro-donations.mo        # Compiled translations
+│   └── gettext.sh                # Translation extraction script
+├── readme.txt                    # WordPress.org plugin readme
+├── readme.md                     # GitHub readme
+├── AGENTS.md                     # This file
+├── PLAN.md                       # Current roadmap and next steps
+└── .github/                      # GitHub templates and workflows
+```
+
+**Key fact**: This is a lightweight plugin (~600 lines of PHP across 5 files). No standalone JavaScript or CSS files — all JS is inline in PHP, all styling uses PMPro core CSS classes.
+
+## Architecture
+
+### Checkout Flow (Execution Order)
+
+When a user checks out on a level with donations enabled:
+
+| # | Hook | Function | File | Purpose |
+|---|------|----------|------|---------|
+| 1 | `pmpro_checkout_preheader_before_get_level_at_checkout` (pri 1) | `pmprodon_init_dropdown_values()` | checkout.php | Copy dropdown selection to `$_REQUEST['donation']` |
+| 2 | `pmpro_checkout_preheader_before_get_level_at_checkout` (pri 10) | `pmprodon_ppe_add_donation_to_request()` | checkout.php | PayPal Express: restore donation from order meta on return |
+| 3 | `pmpro_checkout_preheader` | `pmprodon_pmpro_checkout_preheader()` | checkout.php | Force SSL for donation levels |
+| 4 | `pmpro_checkout_before_form` | `pmprodon_hook_pmpro_level_cost_text()` | checkout.php | Add cost text filter |
+| 5 | `pmpro_checkout_after_user_fields` | `pmprodon_pmpro_checkout_after_user_fields()` | checkout.php | **Render donation form UI** (dropdown or text input) |
+| 6 | `pmpro_checkout_level` (pri 99) | `pmprodon_pmpro_checkout_level()` | checkout.php | **Add donation to `$level->initial_payment`** |
+| 7 | `pmpro_checkout_after_level_cost` | `pmprodon_unhook_pmpro_level_cost_text()` | checkout.php | Remove cost text filter |
+| 8 | `pmpro_registration_checks` | `pmprodon_pmpro_registration_checks()` | checkout.php | **Validate** donation (min, max, negative) |
+| 9 | `pmpro_checkout_before_change_membership_level` (pri 1) | `pmprodon_pmpro_checkout_before_change_membership_level()` | donation-only-level.php | Donation-only: prevent level switching |
+| 10 | `pmpro_after_checkout` | `pmprodon_store_donation_amount_in_order_meta()` | checkout.php | **Save donation to order meta** |
+| 11 | `pmpro_after_checkout` | `pmprodon_pmpro_after_checkout()` | donation-only-level.php | Donation-only: restore member's previous level |
+
+### Data Storage
+
+**Donation Settings** (per level):
+```php
+// Option: pmprodon_{level_id}
+get_option( 'pmprodon_' . $level_id );
+// Returns:
+array(
+    'donations'            => 0|1,       // Enable donations
+    'donations_only'       => 0|1,       // Donation-only level
+    'min_price'            => '5.00',    // Minimum donation
+    'max_price'            => '500.00',  // Maximum donation
+    'dropdown_prices'      => '10,25,50,other',  // Comma-separated
+    'text'                 => '<p>Help text HTML</p>',
+    'confirmation_message' => '<p>Thank you HTML</p>'
+)
+```
+
+**Donation Amount** (per order):
+```php
+// Primary (v2.0+): Order meta
+update_pmpro_membership_order_meta( $order->id, 'donation_amount', $amount );
+get_pmpro_membership_order_meta( $order->id, 'donation_amount', true );
+
+// Legacy (v1.x): Order notes — auto-migrated on first access
+// Pattern: "Donation: 25.00" in $order->notes
+```
+
+### Key Utility Functions
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `pmprodon_get_level_settings( $level_id )` | common.php | Get donation settings for a level (returns array with defaults) |
+| `pmprodon_is_donations_only( $level_id )` | common.php | Check if level is donation-only |
+| `pmprodon_get_price_components( $order )` | common.php | Split order total into `['price' => float, 'donation' => float]` |
+
+### Filters for Customization
+
+| Filter | Purpose |
+|--------|---------|
+| `pmpro_donations_get_price_components` | Customize how order total is split into price + donation |
+| `pmpro_donations_invoice_bullets` | Customize invoice bullet points |
+
+### Email Integration
+
+- **Variable**: `!!donation!!` — replaced with formatted donation amount in all checkout emails
+- **Auto-injection**: If email template doesn't use `!!donation!!`, donation info is injected before the "Invoice" section
+- **Hook**: `pmpro_email_data` and `pmpro_email_filter`
+
+### Donation-Only Levels
+
+Special levels where existing members can donate without losing their current membership:
+
+1. Admin enables "Donations-Only Level" checkbox in level settings
+2. At checkout, plugin prevents cancellation of existing subscriptions (`pmpro_cancel_previous_subscriptions` → `__return_false`)
+3. After checkout, the donation-only level row is removed from `pmpro_memberships_users`
+4. User keeps their original level; donation is recorded on the order
+
+### Inline JavaScript
+
+All JS lives in two places:
+
+**checkout.php** (lines 124-204):
+- `pmprodon_toggleOther()` — show/hide custom amount input when dropdown changes
+- `pmprodon_checkForFree()` — show/hide billing fields based on donation amount and gateway
+- Event listeners on `#donation_dropdown`, `#donation`, and `input[name=gateway]`
+
+**level-settings.php** (lines 85-104):
+- `toggleDonFields()` — show/hide admin settings based on "Enable Donations" checkbox
+
+### CSS Classes Used (from PMPro core)
+
+The plugin uses PMPro's built-in CSS classes — no custom stylesheet:
+- `pmpro_form_fieldset`, `pmpro_card`, `pmpro_card_content`
+- `pmpro_form_field-donation`, `pmpro_form_input-select`, `pmpro_form_input-text`
+- `pmpro_alter_price` — triggers PMPro's price change detection (v2.0+)
+
+## Development Setup
+
+### Local WordPress Environment
+
+This plugin requires an active WordPress installation with Paid Memberships Pro:
+
+```bash
+# Clone into wp-content/plugins/
+cd /path/to/wordpress/wp-content/plugins/
+git clone https://github.com/strangerstudios/pmpro-donations.git
+
+# Or symlink from repos dir
+ln -s ~/repos/strangerstudios/pmpro-donations /path/to/wordpress/wp-content/plugins/pmpro-donations
+
+# Activate via WP CLI
+wp plugin activate pmpro-donations
+```
+
+### Testing Donations
+
+1. Create a membership level in PMPro (Memberships > Settings > Levels)
+2. Edit the level, scroll to "Donation Settings"
+3. Check "Enable Donations", set min/max/dropdown values
+4. Visit the checkout page for that level
+5. For donation-only testing: also check "Donations-Only Level"
+
+### Branching
+
+- **`dev`** — Main development branch (default). PRs target this.
+- **Feature branches** — Named descriptively (e.g., `keep-level`, `payments-free-level`)
+- **No `main`/`master`** — This repo uses `dev` as the default branch
+
+## Coding Conventions
+
+### WordPress Coding Standards
+
+This plugin follows [WordPress PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/):
+
+- **Indentation**: Tabs (not spaces)
+- **Naming**: `snake_case` for functions and variables, prefixed with `pmprodon_`
+- **Strings**: Single quotes for simple strings, double quotes when interpolation needed
+- **Sanitization**: All `$_REQUEST`/`$_GET`/`$_POST` values sanitized with `sanitize_text_field()` and `preg_replace()` for numeric values
+- **Escaping**: Output escaped with `esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()`
+- **i18n**: All user-facing strings wrapped in `__()`, `_e()`, `esc_html_e()`, etc. with text domain `pmpro-donations`
+- **DocBlocks**: PHPDoc on all functions with `@since`, `@param`, `@return`
+
+### Function Prefix
+
+All functions use the `pmprodon_` prefix:
+```php
+pmprodon_get_level_settings()
+pmprodon_pmpro_checkout_level()
+pmprodon_is_donations_only()
+```
+
+### Hook Naming
+
+When hooking into PMPro, the function name mirrors the hook:
+```php
+// Hook: pmpro_after_checkout → Function: pmprodon_pmpro_after_checkout
+add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
+```
+
+### No External Dependencies
+
+The plugin has zero composer or npm dependencies. No build step. PHP only.
+
+## Gateway Considerations
+
+Different payment gateways behave differently with donations:
+
+| Gateway | Behavior | Special Handling |
+|---------|----------|-----------------|
+| **Stripe** | Works normally — donation added to total | None |
+| **PayPal Express** | Donation lost on redirect return | `pmprodon_ppe_add_donation_to_request()` restores from order meta |
+| **Pay by Check** | Known bug: donation amount not saved | Issue #86 — needs fix |
+| **PayPal Standard** | No billing fields needed | JS hides billing fieldset |
+
+Gateways that don't require billing info (handled in checkout JS):
+```javascript
+var no_billing_gateways = ['paypalexpress', 'twocheckout', 'check', 'paypalstandard'];
+```
+
+## Key Issue Patterns
+
+Common areas where bugs appear:
+
+1. **Donation-only levels + level groups** — The interaction between donation-only levels and PMPro's level group system (which controls how many levels a user can hold) is complex and fragile.
+2. **Gateway-specific behavior** — Each payment gateway handles the checkout flow differently, especially around redirects (PayPal) and free levels.
+3. **Price display vs. actual charge** — The plugin modifies `$level->initial_payment` at priority 99 but needs to show the original price in the cost text, requiring careful hook/unhook timing.
+4. **Data format consistency** — Donation amounts should always be stored as clean numeric values. Watch for whitespace and string formatting issues.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,381 @@
+# PMPro Donations — Roadmap (v2.3)
+
+> Target version: **2.3**
+> Branch: `dev-2.3` (create from `dev`)
+> Last updated: 2026-02-23
+
+This plan covers all open issues, ideas meeting items, and open PRs. Work is organized into phases. Each ticket includes acceptance criteria for HomurAI ingestion.
+
+---
+
+## Phase 0: PR Review & Merge
+
+Merge existing open PRs into `dev-2.3` after review. These have been open since early-mid 2025 with no review comments.
+
+### TICKET-001: Merge PR #90 — PHP 8.5 deprecation fix
+- **Type**: Bug Fix
+- **PR**: #90 by @dwanjuki (2026-01-09)
+- **Branch**: `fix-php-8.5-notices` → `dev`
+- **Changes**: Replace `(double)` casts with `(float)` in `checkout.php` (3 occurrences)
+- **Risk**: Low — trivial cast rename, no behavior change
+- **Action**: Merge as-is after confirming no conflicts with `dev`
+- **Acceptance Criteria**:
+  - [ ] No PHP deprecation notices on PHP 8.5+
+  - [ ] All `(double)` casts replaced with `(float)` throughout the plugin
+  - [ ] Checkout validation still works (min/max amounts, price formatting)
+
+### TICKET-002: Merge PR #84 — Payment gateways for free donation levels
+- **Type**: Bug Fix
+- **PR**: #84 by @ipokkel (2025-04-16)
+- **Resolves**: Issue #81 (PayPal Express not shown for free levels with donations)
+- **Branch**: `payments-free-level` → `dev`
+- **Changes**:
+  - New function `pmprodon_enable_payments_for_free_level_donations()` hooked to `pmpro_is_level_free`
+  - If a free level has donations enabled (with min_price > 0 or valid dropdown values), returns `false` so gateways render
+  - Adds validation: if donation is required on free level, donation must be > 0
+- **Review Notes**:
+  - Logic is sound but the edge case where `dropdown_prices` contains only "other" needs testing — should still allow $0 donation in that case
+  - The additional validation (`intval($level->initial_payment) === 0 && donation <= 0`) should only apply when `min_price > 0`, otherwise users should be able to donate $0 on a free level
+- **Acceptance Criteria**:
+  - [ ] PayPal Express and other gateways appear on checkout for free levels with donations enabled
+  - [ ] Billing fields shown when donation amount > 0
+  - [ ] Free level with donations but no min_price still allows $0 checkout
+  - [ ] Free level with min_price > 0 requires a valid donation amount
+
+### TICKET-003: Merge PR #85 — Restore level after donation-only checkout
+- **Type**: Bug Fix
+- **PR**: #85 by @ipokkel (2025-04-18)
+- **Resolves**: Issue #72 (member level changes to donation level), Issue #91 (users keep donation level)
+- **Branch**: `keep-level` → `dev`
+- **Changes**: Complete rewrite of `donation-only-level.php`
+  - Stores user's previous levels in user meta before checkout
+  - After checkout, finds which level was in the same group as donation level
+  - Cancels donation-only level via `pmpro_cancelMembershipLevel()`
+  - Restores original level via `pmpro_changeMembershipLevel()` with full level data
+- **Review Notes**:
+  - The old approach (DELETE SQL query) was fragile. New approach using PMPro API functions is much better.
+  - Need to verify: does `pmpro_cancelMembershipLevel()` trigger unwanted side effects (emails, hooks)?
+  - The stored `pmprodon_previous_levels` user meta should be cleaned up even on failure paths
+  - Test with: single level group, multiple level groups, no level groups, recurring subscription levels
+- **Acceptance Criteria**:
+  - [ ] User with Gold membership donates via donation-only level → keeps Gold membership
+  - [ ] Donation-only level in same level group as user's level → user keeps original level
+  - [ ] Donation-only level in separate level group → user keeps original level
+  - [ ] Recurring subscription not cancelled at gateway after donation-only checkout
+  - [ ] No orphaned `pmprodon_previous_levels` user meta after checkout
+
+### TICKET-004: Review PR #83 — Donations report page
+- **Type**: Feature
+- **PR**: #83 by @vbuster01 (2025-04-04)
+- **Branch**: `dev` → `dev` (⚠️ same branch name — needs rebase)
+- **Changes**: New file `pmpro-donations-report.php` — adds a donations report to PMPro Reports dashboard with filtering and CSV export
+- **Review Notes — Issues to Fix Before Merge**:
+  - File should be in `includes/` directory, not root (follow existing structure)
+  - Functions use `MY_pmpro_` prefix — must be renamed to `pmprodon_` prefix per conventions
+  - Missing `$wpdb->prepare()` on some query parts — security review needed
+  - Uses `date()` instead of `wp_date()` or `gmdate()` — WordPress standards
+  - CSV export uses `$_GET` without nonce verification — needs `wp_verify_nonce()`
+  - File is not `require_once`'d from main plugin file — needs integration
+  - Report should use PMPro's existing report page patterns and styles
+  - Hard-coded `'pmpro'` text domain should be `'pmpro-donations'`
+- **Acceptance Criteria**:
+  - [ ] Report widget appears on PMPro Reports dashboard
+  - [ ] Report page shows total donations with month/year filtering
+  - [ ] Individual donations listed with member details
+  - [ ] CSV export works with proper nonce verification
+  - [ ] All functions use `pmprodon_` prefix
+  - [ ] File located in `includes/reports.php`
+  - [ ] Proper escaping and sanitization on all output and input
+  - [ ] Text domain is `pmpro-donations` throughout
+
+---
+
+## Phase 1: Bug Fixes
+
+### TICKET-005: Fix donation amount not saved with Pay by Check gateway
+- **Type**: Bug Fix
+- **Issue**: #86
+- **Priority**: High
+- **Description**: When using Pay by Check gateway, donation amount is stored as 0 in order meta. Works correctly with Stripe and other gateways.
+- **Root Cause Investigation**: The `pmprodon_store_donation_amount_in_order_meta()` function hooks `pmpro_after_checkout` and reads from `$_REQUEST['donation']`. Pay by Check may handle the checkout flow differently, clearing `$_REQUEST` before this hook fires. Compare the checkout flow for PBC vs Stripe to find where the donation value is lost.
+- **Files**: `includes/checkout.php` (function `pmprodon_store_donation_amount_in_order_meta`)
+- **Acceptance Criteria**:
+  - [ ] Donation amount correctly saved to order meta when using Pay by Check gateway
+  - [ ] Donation amount appears in "Additional Order Information" on admin order page
+  - [ ] Invoice shows correct donation breakdown
+  - [ ] No regression with Stripe, PayPal Express, or other gateways
+
+### TICKET-006: Sanitize donation amounts — trim whitespace
+- **Type**: Bug Fix
+- **Issue**: #89
+- **Priority**: Medium
+- **Description**: Donation amounts with trailing whitespace (e.g., "10 ") are stored as strings with the space, causing them to be excluded from reports and numeric queries.
+- **Fix**: Add `trim()` before storing donation amount. Apply in all storage paths:
+  1. `pmprodon_store_donation_amount_in_order_meta()` in checkout.php
+  2. `pmprodon_pmpro_updated_order()` in admin.php (admin order editing)
+  3. `pmprodon_pmpro_checkout_level()` where donation is read from `$_REQUEST`
+- **Files**: `includes/checkout.php`, `includes/admin.php`
+- **Acceptance Criteria**:
+  - [ ] Donation amounts are trimmed before storage (no leading/trailing whitespace)
+  - [ ] Existing code's `preg_replace('/[^0-9\.]/', ...)` sanitization also strips whitespace — verify this catches the issue or add explicit `trim()`
+  - [ ] Reports correctly count donations after fix
+  - [ ] Admin-entered donation amounts also trimmed
+
+### TICKET-007: Fix donation-only level replacing user's membership
+- **Type**: Bug Fix
+- **Issues**: #72, #91
+- **Priority**: High
+- **Description**: When a user with an existing membership checks out for a donation-only level in a level group, they end up keeping the donation level instead of their original. Two related reports: #72 (level changes to donation level) and #91 (users keep both levels).
+- **Fix**: PR #85 addresses this. See TICKET-003 for merge plan.
+- **Acceptance Criteria**: Same as TICKET-003
+
+---
+
+## Phase 2: Enhancements (from Issues)
+
+### TICKET-008: Donation-specific confirmation email and page
+- **Type**: Enhancement
+- **Issue**: #62
+- **Priority**: Medium
+- **Description**: Checkout confirmation page and emails reference "membership" even for donation-only levels. Should reference "donation" instead.
+- **Implementation**:
+  - Filter `pmpro_confirmation_message` to replace membership language with donation language when checkout is for a donation-only level
+  - Add a new email template (or filter existing checkout emails) for donation-only checkouts
+  - Filter `pmpro_email_data` to provide donation-specific subject lines and body content
+  - Use the existing `confirmation_message` level setting as a starting point
+- **Files**: `includes/checkout.php`, `includes/donation-only-level.php`
+- **Acceptance Criteria**:
+  - [ ] Confirmation page says "Thank you for your donation" instead of "your membership is now active" for donation-only levels
+  - [ ] Checkout email uses donation-appropriate language for donation-only levels
+  - [ ] Regular donation levels (donation + membership) still show standard membership messaging
+  - [ ] Site owner can customize the donation confirmation message per level (already exists)
+
+### TICKET-009: Donor note field at checkout
+- **Type**: Feature
+- **Issue**: #82
+- **Priority**: Medium
+- **Description**: Add an optional "Donation Note" text field at checkout that appears on the invoice and in emails. Common use: "In memory of..." or "For the purpose of..."
+- **Implementation**:
+  - Add new level setting: `donation_note_enabled` (checkbox, optional per level)
+  - Add new level setting: `donation_note_label` (custom label text, default "Donation Note")
+  - Render textarea below donation amount field at checkout
+  - Store note in order meta: key `donation_note`
+  - Add email variable: `!!donation_note!!`
+  - Display on invoice bullets and confirmation page
+- **Files**: `includes/level-settings.php`, `includes/checkout.php`, `includes/admin.php`
+- **Acceptance Criteria**:
+  - [ ] Optional per-level setting to enable donation note field
+  - [ ] Text field appears at checkout below donation amount when enabled
+  - [ ] Note stored in order meta
+  - [ ] Note appears on order invoice page
+  - [ ] `!!donation_note!!` email variable works in templates
+  - [ ] Note visible and editable in admin order edit page
+  - [ ] Note included in CSV export
+
+### TICKET-010: Admin donation field when adding orders
+- **Type**: Enhancement
+- **Issue**: #5
+- **Priority**: Low
+- **Description**: When admin creates an order via "Add New Order" or adds a member via "Add Member", there's no field to specify a donation amount. Currently only works through front-end checkout with payment gateways.
+- **Implementation**:
+  - Hook into `pmpro_after_order_settings` on the add-new-order admin page (may already exist for editing — check `admin.php`)
+  - Show donation amount field when the selected level has donations enabled
+  - Save donation to order meta on order creation
+- **Files**: `includes/admin.php`
+- **Acceptance Criteria**:
+  - [ ] Donation amount field appears when creating new orders in admin
+  - [ ] Field only shows for levels with donations enabled
+  - [ ] Donation amount saved to order meta
+  - [ ] Works with "Add Member" admin page if applicable
+
+---
+
+## Phase 3: Ideas Meeting Features
+
+### TICKET-011: Big and beautiful donation option buttons
+- **Type**: Feature (UI overhaul)
+- **Source**: Ideas meeting (Jason)
+- **Priority**: High
+- **Description**: Replace the plain dropdown with visually appealing donation amount buttons at checkout. Think charity website donation forms — large, clickable amount tiles.
+- **Implementation**:
+  - New display mode when `dropdown_prices` are set: render as button grid instead of `<select>`
+  - Each amount is a clickable card/tile showing the formatted price
+  - "Other" option renders as a compact text input
+  - Selected button gets active state styling
+  - Falls back to text input if no dropdown prices configured
+  - Needs custom CSS (first CSS file in the plugin) or inline styles using PMPro design tokens
+  - Add level setting: `display_mode` (dropdown | buttons) — default buttons for new installs
+- **Files**: `includes/checkout.php` (new rendering), new `css/` directory or inline styles, `includes/level-settings.php`
+- **Acceptance Criteria**:
+  - [ ] Donation amounts display as large, clickable button tiles at checkout
+  - [ ] Selected amount highlighted with active state
+  - [ ] "Other" option shows custom amount text input
+  - [ ] Responsive — works on mobile
+  - [ ] Accessible — keyboard navigable, ARIA labels, focus states
+  - [ ] Level setting to choose between dropdown and button display modes
+  - [ ] Integrates with PMPro's existing checkout styling
+  - [ ] Works with all gateways (Stripe, PayPal, Check)
+
+### TICKET-012: Cover fees checkbox at checkout
+- **Type**: Feature
+- **Source**: Ideas meeting (Jason)
+- **Priority**: High
+- **Description**: Add a "Cover processing fees" checkbox at checkout. When checked, the donation amount is increased to cover payment gateway fees so the organization receives the full intended donation.
+- **Implementation**:
+  - New level setting: `cover_fees_enabled` (checkbox)
+  - New level setting: `cover_fees_percentage` (default 2.9 for Stripe)
+  - New level setting: `cover_fees_flat` (default 0.30 for Stripe)
+  - Render checkbox below donation amount: "Add $X.XX to cover processing fees"
+  - JavaScript calculates fee amount dynamically as donation amount changes
+  - Fee formula: `fee = (donation + flat) / (1 - percentage/100) - donation`
+  - Store original donation and fee separately in order meta: `donation_fee_covered`
+  - Show fee breakdown on invoice
+- **Files**: `includes/checkout.php`, `includes/level-settings.php`, `includes/common.php`
+- **Acceptance Criteria**:
+  - [ ] "Cover processing fees" checkbox at checkout (off by default)
+  - [ ] Fee amount calculated and displayed dynamically
+  - [ ] When checked, total charge increased to cover fees
+  - [ ] Fee percentage and flat amount configurable per level
+  - [ ] Fee amount stored in order meta separately from donation
+  - [ ] Invoice shows: Membership Cost, Donation, Processing Fee Covered
+  - [ ] Works with dynamic amount changes (dropdown selection, custom input)
+
+### TICKET-013: Better donations without a level
+- **Type**: Enhancement
+- **Source**: Ideas meeting (Jason)
+- **Priority**: High
+- **Description**: Improve the donation-only level experience. Current issues: wording still references "membership", levels get swapped in level groups, confirmation is confusing. Make donation-only feel like a proper donation flow, not a membership checkout hack.
+- **Implementation** (builds on TICKET-003, TICKET-007, TICKET-008):
+  - Filter all checkout page text for donation-only levels to use donation language
+  - Hide membership-specific UI elements (account page level listing, expiration dates)
+  - Ensure donation-only levels never replace existing levels (TICKET-003/PR #85)
+  - Don't show donation-only level on membership account page
+  - Custom confirmation page content for donation-only (TICKET-008)
+  - Consider: should donation-only orders even create a membership_users row? Or just an order?
+- **Files**: `includes/donation-only-level.php`, `includes/checkout.php`
+- **Acceptance Criteria**:
+  - [ ] Checkout page uses "donation" language instead of "membership" for donation-only levels
+  - [ ] Donation-only level not shown on membership account page
+  - [ ] Existing member's level not affected by donation-only checkout
+  - [ ] Confirmation page appropriate for donations
+  - [ ] No confusing "your membership level has changed" messaging
+
+### TICKET-014: Different email/confirmation templates per level
+- **Type**: Feature
+- **Source**: Ideas meeting (Kim)
+- **Priority**: Medium
+- **Description**: Users increasingly want to use PMPro for generic purchases, not just memberships. Need a way to have different email confirmation templates and confirmation page content per level type (donation vs membership vs purchase).
+- **Implementation**:
+  - This may be better suited as a PMPro core feature or the Email Templates add-on
+  - For donations specifically: use the existing `confirmation_message` setting (already per-level)
+  - Add email template override per level: hook `pmpro_email_filter` and swap template when checkout level has donations
+  - Add level setting: `email_template_override` — allows selecting a different email template
+- **Dependencies**: May need coordination with pmpro-email-templates add-on
+- **Acceptance Criteria**:
+  - [ ] Donation-only levels can have fully customized confirmation emails
+  - [ ] Confirmation page content customizable per level (already partially works)
+  - [ ] Email uses `!!donation!!` and `!!donation_note!!` variables
+  - [ ] Compatible with Email Templates add-on if installed
+
+### TICKET-015: Guest donations (no account required)
+- **Type**: Feature
+- **Issue**: #22
+- **Priority**: Low (complex, v3.0 candidate)
+- **Description**: Allow donation-only checkout without creating a WordPress user account. For pure donation pages, requiring account creation is friction.
+- **Implementation** (from issue #22):
+  - Add level setting: `allow_guest_donations` (checkbox)
+  - Dropdown on checkout: "Donate as Guest" or "Create Account"
+  - Guest flow: collect email only, create temp user, process payment, delete user after confirmation
+  - Generate random key for confirmation page access
+  - Skip registration fields for guest checkout
+  - Custom confirmation email (no account details)
+- **Risk**: High complexity, touching core PMPro user creation flow
+- **Acceptance Criteria**:
+  - [ ] Guest can donate with only email address
+  - [ ] No persistent WordPress user created for guest donations
+  - [ ] Payment processed and order recorded
+  - [ ] Confirmation page and email work without user account
+  - [ ] Logged-in users don't see the guest/account toggle
+
+### TICKET-016: Donation reminders
+- **Type**: Feature
+- **Issue**: #12
+- **Priority**: Low
+- **Description**: Send periodic reminders to members encouraging them to donate again. Useful for free levels with donation-only functionality.
+- **Implementation**:
+  - Add level setting: `reminder_interval` (none | monthly | quarterly | annually)
+  - Cron job checks for members who donated more than X days ago
+  - Sends reminder email with donation link
+  - Track last donation date per user
+  - Respect unsubscribe/opt-out
+- **Dependencies**: Would benefit from PMPro's existing email infrastructure
+- **Acceptance Criteria**:
+  - [ ] Configurable reminder interval per level
+  - [ ] Reminder emails sent on schedule
+  - [ ] Links directly to donation checkout page
+  - [ ] Tracks last donation date
+  - [ ] Users can opt out of reminders
+
+---
+
+## Phase 4: Donations Report
+
+### TICKET-017: Built-in donations report
+- **Type**: Feature
+- **Issue**: PR #83 (needs significant rework)
+- **Priority**: Medium
+- **Description**: Add a donations report page to PMPro Reports dashboard. PR #83 provides a starting point but needs substantial cleanup before merge.
+- **Implementation** (rework of PR #83):
+  - Move to `includes/reports.php`, rename all functions to `pmprodon_` prefix
+  - Use `$wpdb->prepare()` for all queries
+  - Add nonce verification for CSV export
+  - Use `wp_date()` instead of `date()`
+  - Follow PMPro report page patterns
+  - Add report data: total donations, average donation, donation count, top donors
+  - Month/year filtering with proper UI
+  - CSV export with nonce verification
+- **Acceptance Criteria**:
+  - [ ] Report accessible from PMPro Reports dashboard
+  - [ ] Shows total donations, count, average for selected period
+  - [ ] Individual donation entries with member details
+  - [ ] Month/year filtering
+  - [ ] CSV export with security (nonce, capability check)
+  - [ ] Follows WordPress coding standards and PMPro patterns
+
+---
+
+## Version & Release
+
+**v2.3 Changelog Target**:
+```
+= 2.3 - 2026-XX-XX =
+* BUG FIX: Fixed PHP 8.5 deprecation warnings for (double) cast. (#90)
+* BUG FIX: Fixed PayPal Express and other gateways not showing for free levels with donations. (#81, #84)
+* BUG FIX: Fixed donation-only level replacing member's existing membership in level groups. (#72, #91, #85)
+* BUG FIX: Fixed donation amount not saved when using Pay by Check gateway. (#86)
+* BUG FIX: Fixed donation amounts with whitespace not counted in reports. (#89)
+* FEATURE: Big, beautiful donation amount buttons at checkout. (Ideas meeting)
+* FEATURE: "Cover processing fees" checkbox at checkout. (Ideas meeting)
+* FEATURE: Donor note field at checkout with invoice and email integration. (#82)
+* ENHANCEMENT: Improved donation-only level experience with proper donation language. (#62)
+* ENHANCEMENT: Built-in donations report page with filtering and CSV export. (#83)
+* ENHANCEMENT: Donation amount field on admin Add New Order page. (#5)
+```
+
+**Ticket Priority Order** (recommended processing sequence):
+1. TICKET-001 (PR #90 — trivial merge)
+2. TICKET-006 (whitespace fix — simple)
+3. TICKET-002 (PR #84 — gateway fix)
+4. TICKET-003 (PR #85 — donation-only fix, biggest impact)
+5. TICKET-005 (Pay by Check fix)
+6. TICKET-008 (donation confirmation language)
+7. TICKET-013 (better donation-only experience)
+8. TICKET-011 (donation buttons — high visibility)
+9. TICKET-012 (cover fees checkbox)
+10. TICKET-009 (donor note field)
+11. TICKET-004 (reports PR rework)
+12. TICKET-017 (full reports feature)
+13. TICKET-010 (admin donation field)
+14. TICKET-014 (email templates per level)
+15. TICKET-015 (guest donations — future)
+16. TICKET-016 (donation reminders — future)

--- a/css/pmpro-donations.css
+++ b/css/pmpro-donations.css
@@ -1,0 +1,155 @@
+/**
+ * PMPro Donations — Frontend Styles
+ *
+ * Styles for the donation amount button grid at checkout.
+ *
+ * @since 2.3
+ */
+
+/* -----------------------------------------------
+ * Button Grid Layout
+ * ----------------------------------------------- */
+.pmprodon_buttons_grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+	gap: 12px;
+	margin-bottom: 16px;
+	width: 100%;
+}
+
+/* -----------------------------------------------
+ * Individual Button Tiles
+ * ----------------------------------------------- */
+.pmprodon_button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 16px 12px;
+	border: 2px solid #dcdcde;
+	border-radius: 6px;
+	background: #fff;
+	cursor: pointer;
+	text-align: center;
+	transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+	position: relative;
+	min-height: 56px;
+}
+
+.pmprodon_button:hover {
+	border-color: #2271b1;
+	background-color: #f0f6fc;
+}
+
+.pmprodon_button:focus-within {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+	outline: none;
+}
+
+/* -----------------------------------------------
+ * Active / Selected State
+ * ----------------------------------------------- */
+.pmprodon_button--active {
+	border-color: #2271b1;
+	background-color: #f0f6fc;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+
+.pmprodon_button--active .pmprodon_button_label {
+	font-weight: 700;
+	color: #2271b1;
+}
+
+/* -----------------------------------------------
+ * Visually Hidden Radio Inputs (accessible)
+ * ----------------------------------------------- */
+.pmprodon_button_input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/* -----------------------------------------------
+ * Button Label Text
+ * ----------------------------------------------- */
+.pmprodon_button_label {
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: #1d2327;
+}
+
+/* -----------------------------------------------
+ * Disabled State (review/confirmation mode)
+ * ----------------------------------------------- */
+.pmprodon_button[aria-disabled="true"] {
+	opacity: 0.6;
+	cursor: default;
+	pointer-events: none;
+}
+
+/* -----------------------------------------------
+ * Responsive: Mobile
+ * ----------------------------------------------- */
+@media (max-width: 480px) {
+	.pmprodon_buttons_grid {
+		grid-template-columns: repeat(2, 1fr);
+		gap: 8px;
+	}
+
+	.pmprodon_button {
+		padding: 12px 8px;
+		min-height: 48px;
+	}
+
+	.pmprodon_button_label {
+		font-size: 16px;
+	}
+}
+
+/* -----------------------------------------------
+ * Responsive: Tablet
+ * ----------------------------------------------- */
+@media (min-width: 481px) and (max-width: 768px) {
+	.pmprodon_buttons_grid {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+/* -----------------------------------------------
+ * Cover Fees Checkbox
+ * ----------------------------------------------- */
+.pmprodon_cover_fees_field {
+	margin-top: 16px;
+	padding: 12px 16px;
+	background: #f9f9f9;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+}
+
+.pmprodon_cover_fees_label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+	font-size: 14px;
+	line-height: 1.4;
+	color: #1d2327;
+}
+
+.pmprodon_cover_fees_label input[type="checkbox"] {
+	margin: 0;
+	flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+	.pmprodon_cover_fees_field {
+		padding: 10px 12px;
+	}
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -8,7 +8,9 @@
  * @since 2.0
  */
 function pmprodon_add_donation_column_to_export_orders_csv( $columns ){
-	$columns["donation"] = "pmprodon_extra_order_column_donation";
+	$columns["donation"]            = "pmprodon_extra_order_column_donation";
+	$columns["donation_fee_covered"] = "pmprodon_extra_order_column_donation_fee_covered";
+	$columns["donation_note"]       = "pmprodon_extra_order_column_donation_note";
 
 	return $columns;
 }
@@ -28,34 +30,112 @@ function pmprodon_extra_order_column_donation( $order ){
 }
 
 /**
- * Add donation amount field to the orders page.
+ * CSV column callback for the cover fee amount.
  *
- * @param Object $order The order object.
- * @return void
- * @since 2.0
+ * @since 2.3
+ *
+ * @param object $order The order object.
+ * @return string The cover fee amount.
  */
-function pmprodon_add_donation_field_to_orders_page( $order ) {
-	
-	//get donation amount
-    $price_components = pmprodon_get_price_components( $order );
-	$donation = empty( $price_components['donation'] ) ? '' : $price_components['donation'];
-	?>
-	<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top"><label for="donation"><?php _e( 'Donation Amount', 'pmpro-don' ); ?>:</label></th>
-				<td>
-					<input type="text" id="donation_amount" name="donation_amount" size="20" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $donation ) ); ?>" />
-					<p class="description"><?php _e( 'Enter the donation amount for this order.', 'pmpro-don' ); ?></p>
-				</td>
-			</tr>
-		</tbody>
-	</table>
-	<?php
-
+function pmprodon_extra_order_column_donation_fee_covered( $order ) {
+	$fee = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+	return ! empty( $fee ) ? $fee : '';
 }
 
-add_action( 'pmpro_after_order_settings', 'pmprodon_add_donation_field_to_orders_page'  );
+/**
+ * CSV column callback for the donation note.
+ *
+ * @since 2.3
+ *
+ * @param object $order The order object.
+ * @return string The donation note.
+ */
+function pmprodon_extra_order_column_donation_note( $order ) {
+	return get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+}
+
+/**
+ * Add donation amount field to the orders page.
+ *
+ * Wraps the fields in a container div that is shown or hidden via
+ * inline JavaScript based on whether the selected level has donations
+ * enabled.
+ *
+ * @since 2.0
+ * @since 2.3 Added wrapper div and JS toggle for level-based visibility.
+ *
+ * @param object $order The order object.
+ * @return void
+ */
+function pmprodon_add_donation_field_to_orders_page( $order ) {
+
+	// Get donation amount.
+	$price_components = pmprodon_get_price_components( $order );
+	$donation = empty( $price_components['donation'] ) ? '' : $price_components['donation'];
+
+	// Get donation note.
+	$donation_note = get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+
+	// Get cover fee amount.
+	$fee_covered = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+
+	// Build a JS array of level IDs that have donations enabled.
+	$donation_level_ids = pmprodon_get_donation_enabled_level_ids();
+	?>
+	<div id="pmprodon_admin_donation_fields">
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top"><label for="donation_amount"><?php esc_html_e( 'Donation Amount', 'pmpro-donations' ); ?>:</label></th>
+					<td>
+						<input type="text" id="donation_amount" name="donation_amount" size="20" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $donation ) ); ?>" />
+						<p class="description"><?php esc_html_e( 'Enter the donation amount for this order.', 'pmpro-donations' ); ?></p>
+					</td>
+				</tr>
+				<?php if ( ! empty( $fee_covered ) && (float) $fee_covered > 0 ) { ?>
+				<tr>
+					<th scope="row" valign="top"><label><?php esc_html_e( 'Processing Fee Covered', 'pmpro-donations' ); ?>:</label></th>
+					<td>
+						<p><strong><?php echo esc_html( pmpro_formatPrice( $fee_covered ) ); ?></strong></p>
+						<p class="description"><?php esc_html_e( 'The donor opted to cover processing fees for this order.', 'pmpro-donations' ); ?></p>
+					</td>
+				</tr>
+				<?php } ?>
+				<tr>
+					<th scope="row" valign="top"><label for="donation_note"><?php esc_html_e( 'Donation Note', 'pmpro-donations' ); ?>:</label></th>
+					<td>
+						<textarea id="donation_note" name="donation_note" rows="3" cols="50"><?php echo esc_textarea( $donation_note ); ?></textarea>
+						<p class="description"><?php esc_html_e( 'Enter the donation note for this order.', 'pmpro-donations' ); ?></p>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			var pmprodonLevelIds = <?php echo wp_json_encode( $donation_level_ids ); ?>;
+			var $fields = $( '#pmprodon_admin_donation_fields' );
+			var $levelSelect = $( '#membership_id' );
+
+			function pmprodonToggleDonationFields() {
+				var selectedLevel = parseInt( $levelSelect.val(), 10 );
+				if ( pmprodonLevelIds.indexOf( selectedLevel ) !== -1 ) {
+					$fields.show();
+				} else {
+					$fields.hide();
+				}
+			}
+
+			if ( $levelSelect.length ) {
+				$levelSelect.on( 'change', pmprodonToggleDonationFields );
+				pmprodonToggleDonationFields();
+			}
+		} );
+	</script>
+	<?php
+}
+
+add_action( 'pmpro_after_order_settings', 'pmprodon_add_donation_field_to_orders_page' );
 
 /**
  * Save donation amount to order meta on pmpro_updated_order action execution.
@@ -66,10 +146,140 @@ add_action( 'pmpro_after_order_settings', 'pmprodon_add_donation_field_to_orders
  * @since 2.0
  */
 function pmprodon_save_donation_amount( $order ) {
-	if ( isset( $_REQUEST['donation_amount'] ) && is_admin() && 'pmpro-orders' === $_REQUEST['page'] ) {
-        $float_amount = is_numeric( $_REQUEST['donation_amount'] ) ? floatval( $_REQUEST['donation_amount'] ) : '';
+	if ( ! is_admin() || ! isset( $_REQUEST['page'] ) || 'pmpro-orders' !== $_REQUEST['page'] ) {
+		return;
+	}
+
+	if ( isset( $_REQUEST['donation_amount'] ) ) {
+		$raw_amount   = trim( sanitize_text_field( $_REQUEST['donation_amount'] ) );
+		$float_amount = is_numeric( $raw_amount ) ? floatval( $raw_amount ) : '';
 		update_pmpro_membership_order_meta( $order->id, 'donation_amount', $float_amount );
+	}
+
+	if ( isset( $_REQUEST['donation_note'] ) ) {
+		$donation_note = sanitize_textarea_field( $_REQUEST['donation_note'] );
+		update_pmpro_membership_order_meta( $order->id, 'donation_note', $donation_note );
 	}
 }
 
 add_action( 'pmpro_updated_order', 'pmprodon_save_donation_amount', 10, 1 );
+
+/**
+ * Get an array of level IDs that have donations enabled.
+ *
+ * Used by admin JS to determine which levels should show
+ * the donation fields on the order and Add Member pages.
+ *
+ * @since 2.3
+ *
+ * @return int[] Array of level IDs with donations enabled.
+ */
+function pmprodon_get_donation_enabled_level_ids() {
+	$donation_level_ids = array();
+
+	if ( ! function_exists( 'pmpro_getAllLevels' ) ) {
+		return $donation_level_ids;
+	}
+
+	$levels = pmpro_getAllLevels( true, true );
+	if ( ! empty( $levels ) ) {
+		foreach ( $levels as $level ) {
+			$settings = pmprodon_get_level_settings( $level->id );
+			if ( ! empty( $settings['donations'] ) ) {
+				$donation_level_ids[] = (int) $level->id;
+			}
+		}
+	}
+
+	return $donation_level_ids;
+}
+
+/**
+ * Display donation fields on the Add Member admin page.
+ *
+ * Hooked to 'pmpro_add_member_fields' which fires on the
+ * Memberships > Add Member admin page after the core fields.
+ *
+ * @since 2.3
+ *
+ * @return void
+ */
+function pmprodon_pmpro_add_member_fields() {
+	$donation_level_ids = pmprodon_get_donation_enabled_level_ids();
+	?>
+	<div id="pmprodon_admin_donation_fields" class="pmprodon_add_member_fields">
+		<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top"><label for="donation_amount"><?php esc_html_e( 'Donation Amount', 'pmpro-donations' ); ?>:</label></th>
+					<td>
+						<input type="text" id="donation_amount" name="donation_amount" size="20" value="" />
+						<p class="description"><?php esc_html_e( 'Enter the donation amount for this order.', 'pmpro-donations' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top"><label for="donation_note"><?php esc_html_e( 'Donation Note', 'pmpro-donations' ); ?>:</label></th>
+					<td>
+						<textarea id="donation_note" name="donation_note" rows="3" cols="50"></textarea>
+						<p class="description"><?php esc_html_e( 'Enter the donation note for this order.', 'pmpro-donations' ); ?></p>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			var pmprodonLevelIds = <?php echo wp_json_encode( $donation_level_ids ); ?>;
+			var $fields = $( '#pmprodon_admin_donation_fields' );
+			var $levelSelect = $( '#membership_level_id, #membership_id' );
+
+			function pmprodonToggleDonationFields() {
+				var selectedLevel = parseInt( $levelSelect.val(), 10 );
+				if ( pmprodonLevelIds.indexOf( selectedLevel ) !== -1 ) {
+					$fields.show();
+				} else {
+					$fields.hide();
+				}
+			}
+
+			if ( $levelSelect.length ) {
+				$levelSelect.on( 'change', pmprodonToggleDonationFields );
+				pmprodonToggleDonationFields();
+			}
+		} );
+	</script>
+	<?php
+}
+
+add_action( 'pmpro_add_member_fields', 'pmprodon_pmpro_add_member_fields' );
+
+/**
+ * Save donation amount and note when adding a member via the Add Member page.
+ *
+ * Hooked to 'pmpro_add_member_added' which fires after a member is
+ * created on the Memberships > Add Member admin page.
+ *
+ * @since 2.3
+ *
+ * @param int    $user_id The user ID.
+ * @param object $order   The order object created for the new member.
+ * @return void
+ */
+function pmprodon_pmpro_add_member_added( $user_id, $order ) {
+	if ( empty( $order ) || empty( $order->id ) ) {
+		return;
+	}
+
+	if ( isset( $_REQUEST['donation_amount'] ) ) {
+		$raw_amount   = trim( sanitize_text_field( $_REQUEST['donation_amount'] ) );
+		$float_amount = is_numeric( $raw_amount ) ? floatval( $raw_amount ) : '';
+		update_pmpro_membership_order_meta( $order->id, 'donation_amount', $float_amount );
+	}
+
+	if ( isset( $_REQUEST['donation_note'] ) ) {
+		$donation_note = sanitize_textarea_field( $_REQUEST['donation_note'] );
+		update_pmpro_membership_order_meta( $order->id, 'donation_note', $donation_note );
+	}
+}
+
+add_action( 'pmpro_add_member_added', 'pmprodon_pmpro_add_member_added', 10, 2 );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -77,7 +77,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 									<?php
 									foreach ( $dropdown_prices as $price ) {
 										?>
-										<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (double) $price ) ); ?></option>
+										<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (float) $price ) ); ?></option>
 										<?php
 									}
 									if ( $pmprodon_allow_other ) {
@@ -254,11 +254,11 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 			$donation = sanitize_text_field( preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] ) );
 
 			// check that the donation falls between the min and max
-			if ( (double) $donation < 0 || ( ! empty( $donfields['min_price'] ) && (double) $donation < (double) $donfields['min_price'] ) ) {
+			if ( (float) $donation < 0 || ( ! empty( $donfields['min_price'] ) && (float) $donation < (float) $donfields['min_price'] ) ) {
 				$pmpro_msg  = sprintf( __( 'The lowest accepted donation is %s. Please enter a new amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['min_price'] ) );
 				$pmpro_msgt = 'pmpro_error';
 				$continue   = false;
-			} elseif ( ! empty( $donfields['max_price'] ) && (double) $donation > (double) $donfields['max_price'] ) {
+			} elseif ( ! empty( $donfields['max_price'] ) && (float) $donation > (float) $donfields['max_price'] ) {
 				$pmpro_msg = sprintf( __( 'The highest accepted donation is %s. Please enter a new amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['max_price'] ) );
 
 				$pmpro_msgt = 'pmpro_error';

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -1289,6 +1289,7 @@ function pmprodon_setup_guest_donor_user( $user_id ) {
 
 	// Mark user as a guest donor.
 	update_user_meta( $user_id, 'pmprodon_is_guest_donor', 1 );
+	update_user_meta( $user_id, 'pmprodon_guest_created', current_time( 'timestamp' ) );
 
 	// Remove all roles so the user cannot log in.
 	$user = new WP_User( $user_id );
@@ -1316,7 +1317,9 @@ function pmprodon_store_guest_confirmation_key( $user_id, $order ) {
 	}
 
 	$confirmation_key = pmprodon_generate_confirmation_key();
+	$key_created_at   = current_time( 'timestamp' );
 	update_pmpro_membership_order_meta( $order->id, 'pmprodon_confirmation_key', $confirmation_key );
+	update_pmpro_membership_order_meta( $order->id, 'pmprodon_confirmation_key_created', $key_created_at );
 
 	// Store the guest flag on the order meta for easy lookup.
 	update_pmpro_membership_order_meta( $order->id, 'pmprodon_is_guest_order', 1 );
@@ -1445,6 +1448,17 @@ function pmprodon_handle_confirmation_key_access() {
 		return;
 	}
 
+	// Enforce expiration for confirmation-key access.
+	$key_created_at = intval( get_pmpro_membership_order_meta( $order_id, 'pmprodon_confirmation_key_created', true ) );
+	$key_lifetime   = apply_filters( 'pmprodon_confirmation_key_lifetime', 30 * DAY_IN_SECONDS );
+	if ( empty( $key_created_at ) ) {
+		$order_for_timestamp = new MemberOrder( $order_id );
+		$key_created_at      = $order_for_timestamp->getTimestamp();
+	}
+	if ( empty( $key_created_at ) || ( current_time( 'timestamp' ) - intval( $key_created_at ) ) > $key_lifetime ) {
+		return;
+	}
+
 	// Load the order and set up the global for the confirmation template.
 	$order = new MemberOrder( $order_id );
 	if ( empty( $order->id ) ) {
@@ -1459,6 +1473,59 @@ function pmprodon_handle_confirmation_key_access() {
 	wp_set_current_user( $order->user_id );
 }
 add_action( 'template_redirect', 'pmprodon_handle_confirmation_key_access', 1 );
+
+/**
+ * Clean up stale guest-donor user accounts.
+ *
+ * Guest users are temporary operational accounts used to process checkout.
+ * This daily cleanup keeps them from persisting indefinitely.
+ *
+ * @since 2.3
+ */
+function pmprodon_cleanup_stale_guest_donor_users() {
+	if ( ! function_exists( 'get_users' ) ) {
+		return;
+	}
+
+	$retention_seconds = apply_filters( 'pmprodon_guest_user_retention', 45 * DAY_IN_SECONDS );
+	$cutoff            = current_time( 'timestamp' ) - intval( $retention_seconds );
+
+	$per_page = 200;
+	do {
+		$guest_ids = get_users(
+			array(
+				'fields'     => 'ID',
+				'number'     => $per_page,
+				'meta_query' => array(
+					'relation' => 'AND',
+					array(
+						'key'   => 'pmprodon_is_guest_donor',
+						'value' => 1,
+					),
+					array(
+						'key'     => 'pmprodon_guest_created',
+						'value'   => $cutoff,
+						'compare' => '<=',
+						'type'    => 'NUMERIC',
+					),
+				),
+			)
+		);
+
+		if ( empty( $guest_ids ) ) {
+			break;
+		}
+
+		foreach ( $guest_ids as $guest_id ) {
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+			wp_delete_user( intval( $guest_id ) );
+		}
+
+	} while ( count( $guest_ids ) === $per_page );
+}
+add_action( 'pmprodon_donation_reminders_cron', 'pmprodon_cleanup_stale_guest_donor_users', 20 );
 
 /**
  * Restore guest checkout state for PayPal Express redirect flow.

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -89,10 +89,10 @@ function pmprodon_render_guest_checkout_toggle() {
 					$('#password2').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').hide();
 					// Set placeholder values for hidden fields.
 					if ($('#username').length && !$('#username').val()) {
-						$('#username').val('guest_donor_' + Math.random().toString(36).substr(2, 8));
+						$('#username').val('guest_donor_' + Math.random().toString(36).substring(2, 10));
 					}
 					if ($('#password').length && !$('#password').val()) {
-						var guestPwd = Math.random().toString(36).substr(2, 20) + Math.random().toString(36).substr(2, 20);
+						var guestPwd = Math.random().toString(36).substring(2, 22) + Math.random().toString(36).substring(2, 22);
 						$('#password').val(guestPwd);
 						$('#password2, #password2_confirm').val(guestPwd);
 					}
@@ -914,16 +914,15 @@ function pmprodon_pmpro_email_filter( $email ) {
 	// Replace membership language with donation language for donation-only levels.
 	if ( ! empty( $order->membership_id ) && pmprodon_is_donations_only( $order->membership_id ) ) {
 		// Replace common membership phrases with donation equivalents.
+		// Use __() on search keys so replacements work on translated PMPro sites.
 		$replacements = array(
-			'Your membership account is now active.'     => __( 'Your donation has been received.', 'pmpro-donations' ),
-			'your membership account is now active.'     => __( 'your donation has been received.', 'pmpro-donations' ),
-			'Thank you for your membership'              => __( 'Thank you for your donation', 'pmpro-donations' ),
-			'thank you for your membership'              => __( 'thank you for your donation', 'pmpro-donations' ),
-			'membership level has been changed'          => __( 'donation has been processed', 'pmpro-donations' ),
-			'has changed their membership level'         => __( 'has made a donation', 'pmpro-donations' ),
-			'your membership confirmation'               => __( 'your donation confirmation', 'pmpro-donations' ),
-			'Your membership confirmation'               => __( 'Your donation confirmation', 'pmpro-donations' ),
-			'Membership Level:'                          => __( 'Donation:', 'pmpro-donations' ),
+			__( 'Your membership account is now active.', 'paid-memberships-pro' )  => __( 'Your donation has been received.', 'pmpro-donations' ),
+			__( 'Thank you for your membership', 'paid-memberships-pro' )           => __( 'Thank you for your donation', 'pmpro-donations' ),
+			__( 'membership level has been changed', 'paid-memberships-pro' )       => __( 'donation has been processed', 'pmpro-donations' ),
+			__( 'has changed their membership level', 'paid-memberships-pro' )      => __( 'has made a donation', 'pmpro-donations' ),
+			__( 'your membership confirmation', 'paid-memberships-pro' )            => __( 'your donation confirmation', 'pmpro-donations' ),
+			__( 'Your membership confirmation', 'paid-memberships-pro' )            => __( 'Your donation confirmation', 'pmpro-donations' ),
+			__( 'Membership Level:', 'paid-memberships-pro' )                       => __( 'Donation:', 'pmpro-donations' ),
 		);
 
 		foreach ( $replacements as $search => $replace ) {
@@ -1394,7 +1393,7 @@ function pmprodon_filter_guest_donor_email( $email ) {
 
 	return $email;
 }
-add_filter( 'pmpro_email_filter', 'pmprodon_filter_guest_donor_email', 5, 2 );
+add_filter( 'pmpro_email_filter', 'pmprodon_filter_guest_donor_email', 5 );
 
 /**
  * Handle confirmation key access for guest donors.

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -207,6 +207,58 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 add_action( 'pmpro_checkout_after_user_fields', 'pmprodon_pmpro_checkout_after_user_fields' );
 
 /**
+ * Enable payment gateways for free levels that have donations enabled.
+ *
+ * If a free level has donations enabled with a min_price > 0 or
+ * dropdown_prices containing numeric values > 0, mark the level
+ * as non-free so that payment gateways render on checkout.
+ *
+ * @since 2.3
+ *
+ * @param bool   $is_free Whether the level is free.
+ * @param object $level   The level object being checked.
+ * @return bool Whether the level should be treated as free.
+ */
+function pmprodon_enable_payments_for_free_level_donations( $is_free, $level ) {
+	// Only act on free levels during checkout.
+	if ( ! $is_free || ! pmpro_is_checkout() ) {
+		return $is_free;
+	}
+
+	// Get donation settings for this level.
+	$donfields = pmprodon_get_level_settings( $level->id );
+
+	// If donations are not enabled, leave as-is.
+	if ( empty( $donfields['donations'] ) ) {
+		return $is_free;
+	}
+
+	// Check if min_price requires a donation.
+	if ( ! empty( $donfields['min_price'] ) && (float) $donfields['min_price'] > 0 ) {
+		return false;
+	}
+
+	// Check if dropdown_prices contain numeric values > 0.
+	if ( ! empty( $donfields['dropdown_prices'] ) ) {
+		$prices = str_replace( ' ', '', $donfields['dropdown_prices'] );
+		$prices = explode( ',', $prices );
+		$has_numeric = false;
+		foreach ( $prices as $price ) {
+			if ( $price !== 'other' && (float) $price > 0 ) {
+				$has_numeric = true;
+				break;
+			}
+		}
+		if ( $has_numeric ) {
+			return false;
+		}
+	}
+
+	return $is_free;
+}
+add_filter( 'pmpro_is_level_free', 'pmprodon_enable_payments_for_free_level_donations', 10, 2 );
+
+/**
  * Set price at checkout
  */
 function pmprodon_pmpro_checkout_level( $level ) {
@@ -261,6 +313,13 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 			} elseif ( ! empty( $donfields['max_price'] ) && (float) $donation > (float) $donfields['max_price'] ) {
 				$pmpro_msg = sprintf( __( 'The highest accepted donation is %s. Please enter a new amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['max_price'] ) );
 
+				$pmpro_msgt = 'pmpro_error';
+				$continue   = false;
+			}
+
+			// Free levels with min_price > 0 require a donation amount.
+			if ( $continue && ! empty( $donfields['min_price'] ) && (float) $donfields['min_price'] > 0 && intval( $level->initial_payment ) === 0 && (float) $donation <= 0 ) {
+				$pmpro_msg  = sprintf( __( 'A donation of at least %s is required. Please enter a donation amount.', 'pmpro-donations' ), pmpro_formatPrice( $donfields['min_price'] ) );
 				$pmpro_msgt = 'pmpro_error';
 				$continue   = false;
 			}

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -19,6 +19,114 @@ function pmprodon_init_dropdown_values() {
 add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmprodon_init_dropdown_values', 1 );
 
 /**
+ * Render the guest/account checkout toggle for donation-only levels
+ * that allow guest donations.
+ *
+ * Only shown to non-logged-in users on levels with both donations_only
+ * and allow_guest_donations enabled. Logged-in users see the standard
+ * checkout flow.
+ *
+ * @since 2.3
+ */
+function pmprodon_render_guest_checkout_toggle() {
+	global $pmpro_level;
+
+	// Only show for non-logged-in users.
+	if ( is_user_logged_in() ) {
+		return;
+	}
+
+	// Only show for donation-only levels with guest donations enabled.
+	if ( empty( $pmpro_level->id ) ) {
+		return;
+	}
+
+	$settings = pmprodon_get_level_settings( $pmpro_level->id );
+	if ( empty( $settings['donations'] ) || empty( $settings['donations_only'] ) || empty( $settings['allow_guest_donations'] ) ) {
+		return;
+	}
+
+	// Block guest checkout for recurring levels.
+	if ( ! empty( $pmpro_level->billing_amount ) && (float) $pmpro_level->billing_amount > 0 ) {
+		return;
+	}
+
+	$guest_selected = ! empty( $_REQUEST['pmprodon_guest'] ) && $_REQUEST['pmprodon_guest'] === '1';
+	?>
+	<fieldset id="pmpro_form_fieldset-guest-checkout" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_form_fieldset-guest-checkout' ) ); ?>">
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+				<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
+					<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Checkout Method', 'pmpro-donations' ); ?></h2>
+				</legend>
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>">
+						<label>
+							<input type="radio" name="pmprodon_guest" value="1" <?php checked( $guest_selected ); ?> />
+							<?php esc_html_e( 'Donate as Guest', 'pmpro-donations' ); ?>
+						</label>
+						<br />
+						<label>
+							<input type="radio" name="pmprodon_guest" value="0" <?php checked( ! $guest_selected ); ?> />
+							<?php esc_html_e( 'Create an Account', 'pmpro-donations' ); ?>
+						</label>
+					</div>
+				</div>
+			</div>
+		</div>
+	</fieldset>
+	<script>
+		jQuery(document).ready(function($) {
+			function pmprodon_toggleGuestFields() {
+				var isGuest = $('input[name="pmprodon_guest"]:checked').val() === '1';
+				if (isGuest) {
+					// Hide username and password fields.
+					$('#pmpro_user_fields-username, #pmpro_user_fields-password').closest('.<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').hide();
+					// Also hide by ID patterns used in PMPro.
+					$('#username, #password, #password2, #password2_confirm').closest('div').hide();
+					$('#username').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').hide();
+					$('#password').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').hide();
+					$('#password2').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').hide();
+					// Set placeholder values for hidden fields.
+					if ($('#username').length && !$('#username').val()) {
+						$('#username').val('guest_donor_' + Math.random().toString(36).substr(2, 8));
+					}
+					if ($('#password').length && !$('#password').val()) {
+						var guestPwd = Math.random().toString(36).substr(2, 20) + Math.random().toString(36).substr(2, 20);
+						$('#password').val(guestPwd);
+						$('#password2, #password2_confirm').val(guestPwd);
+					}
+				} else {
+					// Show username and password fields.
+					$('#pmpro_user_fields-username, #pmpro_user_fields-password').closest('.<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').show();
+					$('#username').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').show();
+					$('#password').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').show();
+					$('#password2').closest('.' + '<?php echo esc_js( pmpro_get_element_class( 'pmpro_form_field' ) ); ?>').show();
+					$('#username, #password, #password2, #password2_confirm').closest('div').show();
+					// Clear auto-generated values if user switches back.
+					if ($('#username').val().indexOf('guest_donor_') === 0) {
+						$('#username').val('');
+					}
+					if ($('#password').val().length > 30) {
+						$('#password').val('');
+						$('#password2, #password2_confirm').val('');
+					}
+				}
+			}
+
+			$('input[name="pmprodon_guest"]').on('change', function() {
+				pmprodon_toggleGuestFields();
+			});
+
+			// Run on page load.
+			pmprodon_toggleGuestFields();
+		});
+	</script>
+	<?php
+}
+add_action( 'pmpro_checkout_after_pricing_fields', 'pmprodon_render_guest_checkout_toggle' );
+
+/**
  * Show form at checkout.
  */
 function pmprodon_pmpro_checkout_after_user_fields() {
@@ -36,6 +144,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 	$min_price = $donfields['min_price'];
 	$max_price = $donfields['max_price'];
 	$dropdown_prices = $donfields['dropdown_prices'];
+	$display_mode = isset( $donfields['display_mode'] ) ? $donfields['display_mode'] : 'dropdown';
 
 	if ( isset( $_REQUEST['donation'] ) ) {
 		$donation = preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] );
@@ -57,7 +166,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 						<label for="donation" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Donation Amount', 'pmpro-donations' ); ?></label>
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
 							<?php
-							// check for dropdown
+							// check for dropdown prices
 							if ( ! empty( $dropdown_prices ) ) {
 								// turn into an array
 								$dropdown_prices = str_replace( ' ', '', $dropdown_prices );
@@ -70,24 +179,53 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 									$pmprodon_allow_other = true;
 								}
 
-								// show dropdown
+								// sort numeric prices
 								sort( $dropdown_prices );
-								?>
-								<select id="donation_dropdown" name="donation_dropdown" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select pmpro_alter_price' ) ); ?>" <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?>>
-									<?php
-									foreach ( $dropdown_prices as $price ) {
-										?>
-										<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (float) $price ) ); ?></option>
-										<?php
+
+								if ( $display_mode === 'buttons' ) {
+									// Default to first price if no donation selected yet.
+									if ( empty( $donation ) && ! empty( $dropdown_prices ) ) {
+										$donation = $dropdown_prices[0];
 									}
-									if ( $pmprodon_allow_other ) {
-										?>
-										<option value="other" <?php selected( true, ! empty( $donation ) && ! in_array( $donation, $dropdown_prices ) ); ?>>
-											<?php esc_html_e( 'Other', 'pmpro-donations' ) ?>
-										</option>
-									<?php } ?>
-								</select>
-								<?php
+									// Determine which button is currently selected.
+									$is_other_selected = ! empty( $donation ) && ! in_array( $donation, $dropdown_prices );
+									?>
+									<div class="pmprodon_buttons_grid" role="radiogroup" aria-label="<?php esc_attr_e( 'Donation Amount', 'pmpro-donations' ); ?>">
+										<?php foreach ( $dropdown_prices as $price ) {
+											$is_checked = ! $is_other_selected && $price == $donation;
+											?>
+											<label class="pmprodon_button <?php echo $is_checked ? 'pmprodon_button--active' : ''; ?>" <?php if ( $pmpro_review ) { ?>aria-disabled="true"<?php } ?>>
+												<input type="radio" name="donation_dropdown" value="<?php echo esc_attr( $price ); ?>" <?php checked( $is_checked ); ?> <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?> class="pmprodon_button_input" />
+												<span class="pmprodon_button_label"><?php echo esc_html( pmpro_formatPrice( (float) $price ) ); ?></span>
+											</label>
+										<?php } ?>
+										<?php if ( $pmprodon_allow_other ) { ?>
+											<label class="pmprodon_button pmprodon_button--other <?php echo $is_other_selected ? 'pmprodon_button--active' : ''; ?>" <?php if ( $pmpro_review ) { ?>aria-disabled="true"<?php } ?>>
+												<input type="radio" name="donation_dropdown" value="other" <?php checked( $is_other_selected ); ?> <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?> class="pmprodon_button_input" />
+												<span class="pmprodon_button_label"><?php esc_html_e( 'Other', 'pmpro-donations' ); ?></span>
+											</label>
+										<?php } ?>
+									</div>
+									<?php
+								} else {
+									// Classic dropdown mode.
+									?>
+									<select id="donation_dropdown" name="donation_dropdown" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select pmpro_alter_price' ) ); ?>" <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?>>
+										<?php
+										foreach ( $dropdown_prices as $price ) {
+											?>
+											<option <?php selected( $price, $donation ); ?> value="<?php echo esc_attr( $price ); ?>"><?php echo esc_html( pmpro_formatPrice( (float) $price ) ); ?></option>
+											<?php
+										}
+										if ( $pmprodon_allow_other ) {
+											?>
+											<option value="other" <?php selected( true, ! empty( $donation ) && ! in_array( $donation, $dropdown_prices ) ); ?>>
+												<?php esc_html_e( 'Other', 'pmpro-donations' ) ?>
+											</option>
+										<?php } ?>
+									</select>
+									<?php
+								}
 							}
 							?>
 							<span id="pmprodon_donation_input" <?php if ( ! empty( $pmprodon_allow_other ) && ( empty( $_REQUEST['donation_dropdown'] ) || $_REQUEST['donation_dropdown'] != 'other' ) ) { ?>style="display: none;"<?php } ?>>
@@ -117,6 +255,52 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 						}
 						?>
 					</div> <!-- end pmpro_form_field-donation -->
+					<?php
+					// Donation note textarea.
+					$donfields_full = pmprodon_get_level_settings( $pmpro_level->id );
+					if ( ! empty( $donfields_full['donation_note_enabled'] ) ) {
+						$donation_note_label = ! empty( $donfields_full['donation_note_label'] ) ? $donfields_full['donation_note_label'] : __( 'Donation Note', 'pmpro-donations' );
+						$donation_note_value = isset( $_REQUEST['donation_note'] ) ? sanitize_textarea_field( $_REQUEST['donation_note'] ) : '';
+						?>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-donation-note', 'pmpro_form_field-donation-note' ) ); ?>">
+							<label for="donation_note" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php echo esc_html( $donation_note_label ); ?></label>
+							<textarea id="donation_note" name="donation_note" rows="3" cols="50" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-textarea' ) ); ?>" <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?>><?php echo esc_textarea( $donation_note_value ); ?></textarea>
+							<?php if ( $pmpro_review && ! empty( $donation_note_value ) ) { ?>
+								<input type="hidden" name="donation_note" value="<?php echo esc_attr( $donation_note_value ); ?>" />
+							<?php } ?>
+						</div> <!-- end pmpro_form_field-donation-note -->
+						<?php
+					}
+
+					// Cover fees checkbox.
+					if ( ! empty( $donfields_full['cover_fees_enabled'] ) ) {
+						$cover_fees_percentage = (float) $donfields_full['cover_fees_percentage'];
+						$cover_fees_flat       = (float) $donfields_full['cover_fees_flat'];
+						$initial_fee           = pmprodon_calculate_cover_fee( (float) $donation, $cover_fees_percentage, $cover_fees_flat );
+						$cover_fees_checked    = ! empty( $_REQUEST['cover_fees'] ) ? true : false;
+						?>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-cover-fees', 'pmpro_form_field-cover-fees' ) ); ?> pmprodon_cover_fees_field">
+							<label for="cover_fees" class="pmprodon_cover_fees_label">
+								<input type="checkbox" id="cover_fees" name="cover_fees" value="1" <?php checked( $cover_fees_checked ); ?> <?php if ( $pmpro_review ) { ?>disabled="disabled"<?php } ?> />
+								<span id="pmprodon_cover_fees_text">
+									<?php
+									echo esc_html(
+										sprintf(
+											/* translators: %s: the calculated fee amount */
+											__( 'Add %s to cover processing fees', 'pmpro-donations' ),
+											pmpro_formatPrice( $initial_fee )
+										)
+									);
+									?>
+								</span>
+							</label>
+							<?php if ( $pmpro_review && $cover_fees_checked ) { ?>
+								<input type="hidden" name="cover_fees" value="1" />
+							<?php } ?>
+						</div> <!-- end pmpro_form_field-cover-fees -->
+						<?php
+					}
+					?>
 				</div> <!-- end pmpro_form_fields -->
 			</div> <!-- end pmpro_card_content -->
 		</div> <!-- end pmpro_card -->
@@ -126,18 +310,40 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 		var pmpro_gateway_billing = <?php if ( in_array( $gateway, array( 'paypalexpress', 'twocheckout' ) ) !== false ) { echo'false';	} else { echo 'true'; } ?>;
 		var pmpro_pricing_billing = <?php if ( ! pmpro_isLevelFree( $pmpro_level ) ) { echo 'true';	} else { echo 'false'; } ?>;
 		var pmpro_donation_billing = pmpro_pricing_billing;
+		var pmprodon_display_mode = '<?php echo esc_js( $display_mode ); ?>';
+		var pmprodon_cover_fees_enabled = <?php echo ! empty( $donfields_full['cover_fees_enabled'] ) ? 'true' : 'false'; ?>;
+		var pmprodon_cover_fees_percentage = <?php echo (float) ( ! empty( $donfields_full['cover_fees_percentage'] ) ? $donfields_full['cover_fees_percentage'] : 0 ); ?>;
+		var pmprodon_cover_fees_flat = <?php echo (float) ( ! empty( $donfields_full['cover_fees_flat'] ) ? $donfields_full['cover_fees_flat'] : 0 ); ?>;
 
 		//this script will hide show billing fields based on the price set
 		jQuery(document).ready(function() {
-			//bind other field toggle to dropdown change
-			jQuery('#donation_dropdown').change(function() {
-				pmprodon_toggleOther();
-				// If we changed to a non-other value, update the donation field.
-				if ( jQuery( '#donation_dropdown' ).val() !== 'other' ) {
-					jQuery( '#donation' ).val( jQuery( '#donation_dropdown' ).val() );
-				}
-				pmprodon_checkForFree();
-			});
+			if ( pmprodon_display_mode === 'buttons' ) {
+				// Button mode: handle radio button changes.
+				jQuery('.pmprodon_button_input').on('change', function() {
+					var $label = jQuery(this).closest('.pmprodon_button');
+					// Remove active class from all buttons.
+					jQuery('.pmprodon_button').removeClass('pmprodon_button--active');
+					// Add active class to selected button.
+					$label.addClass('pmprodon_button--active');
+					// Toggle the other input.
+					pmprodon_toggleOther();
+					// If not 'other', update the donation field with the selected value.
+					if ( jQuery(this).val() !== 'other' ) {
+						jQuery('#donation').val( jQuery(this).val() );
+					}
+					pmprodon_checkForFree();
+				});
+			} else {
+				// Dropdown mode: bind to select change.
+				jQuery('#donation_dropdown').change(function() {
+					pmprodon_toggleOther();
+					// If we changed to a non-other value, update the donation field.
+					if ( jQuery( '#donation_dropdown' ).val() !== 'other' ) {
+						jQuery( '#donation' ).val( jQuery( '#donation_dropdown' ).val() );
+					}
+					pmprodon_checkForFree();
+				});
+			}
 
 			//bind check to price field
 			var pmprodon_price_timer;
@@ -152,23 +358,39 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 				});
 			}
 
+			//update cover fees when checkbox is toggled
+			jQuery('#cover_fees').on('change', function() {
+				pmprodon_updateCoverFees();
+			});
+
 			//check when page loads too
 			pmprodon_toggleOther();
 			pmprodon_checkForFree();
 		});
 
 		function pmprodon_toggleOther() {
-			//make sure there is a dropdown to check
-			if(!jQuery('#donation_dropdown').length)
-				return;
+			var donation_dropdown_val;
 
-			//get val
-			var donation_dropdown = jQuery('#donation_dropdown').val();
+			if ( pmprodon_display_mode === 'buttons' ) {
+				// In button mode, get the checked radio value.
+				var $checked = jQuery('.pmprodon_button_input:checked');
+				if ( ! $checked.length ) {
+					return;
+				}
+				donation_dropdown_val = $checked.val();
+			} else {
+				// In dropdown mode, get the select value.
+				if ( ! jQuery('#donation_dropdown').length ) {
+					return;
+				}
+				donation_dropdown_val = jQuery('#donation_dropdown').val();
+			}
 
-			if(donation_dropdown == 'other')
+			if ( donation_dropdown_val == 'other' ) {
 				jQuery('#pmprodon_donation_input').show();
-			else
+			} else {
 				jQuery('#pmprodon_donation_input').hide();
+			}
 		}
 
 		function pmprodon_checkForFree() {
@@ -200,6 +422,42 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 				jQuery('#pmpro_payment_information_fields').hide();
 				pmpro_require_billing = false;
 			}
+
+			// Update cover fees when donation changes.
+			pmprodon_updateCoverFees();
+		}
+
+		function pmprodon_updateCoverFees() {
+			if ( ! pmprodon_cover_fees_enabled ) {
+				return;
+			}
+			var $text = jQuery('#pmprodon_cover_fees_text');
+			if ( ! $text.length ) {
+				return;
+			}
+			var donation = parseFloat(jQuery('#donation').val()) || 0;
+			var fee = 0;
+			if ( donation > 0 && pmprodon_cover_fees_percentage < 100 ) {
+				fee = ( donation + pmprodon_cover_fees_flat ) / ( 1 - pmprodon_cover_fees_percentage / 100 ) - donation;
+				fee = Math.round( fee * 100 ) / 100;
+			}
+			// Format fee for display. Use the currency symbol from the page.
+			var feeFormatted = fee.toFixed(2);
+			<?php
+			// Pass the currency symbol and position to JS for fee formatting.
+			$currency_position = apply_filters( 'pmpro_currency_position', 'left' );
+			?>
+			var currencySymbol = '<?php echo esc_js( $pmpro_currency_symbol ); ?>';
+			var currencyPosition = '<?php echo esc_js( $currency_position ); ?>';
+			var priceStr;
+			if ( currencyPosition === 'right' ) {
+				priceStr = feeFormatted + currencySymbol;
+			} else {
+				priceStr = currencySymbol + feeFormatted;
+			}
+			/* translators: %s: the calculated fee amount */
+			var template = '<?php echo esc_js( sprintf( __( 'Add %s to cover processing fees', 'pmpro-donations' ), '{FEE}' ) ); ?>';
+			$text.text( template.replace( '{FEE}', priceStr ) );
 		}
 	</script>
 	<?php
@@ -264,7 +522,7 @@ add_filter( 'pmpro_is_level_free', 'pmprodon_enable_payments_for_free_level_dona
 function pmprodon_pmpro_checkout_level( $level ) {
 
 	if ( isset( $_REQUEST['donation'] ) ) {
-		$donation = sanitize_text_field( preg_replace( '/[^0-9\.]/', '', $_REQUEST['donation'] ) );
+		$donation = sanitize_text_field( preg_replace( '/[^0-9\.]/', '', trim( $_REQUEST['donation'] ) ) );
 	} else {
 		return $level;
 	}
@@ -276,6 +534,35 @@ function pmprodon_pmpro_checkout_level( $level ) {
 
 		// add donation
 		$level->initial_payment = $level->initial_payment + $donation;
+	}
+
+	// Store the sanitized donation amount in a global so it is available
+	// later in the checkout flow, even if $_REQUEST is cleared by the gateway
+	// (e.g., Pay by Check). This fires at pmpro_checkout_level priority 99,
+	// before pmpro_after_checkout where the value is saved to order meta.
+	global $pmprodon_donation_amount;
+	$pmprodon_donation_amount = $donation;
+
+	// Calculate and add cover fee if the checkbox is checked.
+	global $pmprodon_cover_fee_amount;
+	$pmprodon_cover_fee_amount = 0;
+	if ( ! empty( $_REQUEST['cover_fees'] ) ) {
+		$donfields_settings = pmprodon_get_level_settings( $level->id );
+		if ( ! empty( $donfields_settings['cover_fees_enabled'] ) ) {
+			$fee_percentage = (float) $donfields_settings['cover_fees_percentage'];
+			$fee_flat       = (float) $donfields_settings['cover_fees_flat'];
+			$cover_fee      = pmprodon_calculate_cover_fee( (float) $donation, $fee_percentage, $fee_flat );
+			if ( $cover_fee > 0 ) {
+				$level->initial_payment   = $level->initial_payment + $cover_fee;
+				$pmprodon_cover_fee_amount = $cover_fee;
+			}
+		}
+	}
+
+	// Store the donation note in a global for the same reason.
+	global $pmprodon_donation_note;
+	if ( isset( $_REQUEST['donation_note'] ) ) {
+		$pmprodon_donation_note = sanitize_textarea_field( $_REQUEST['donation_note'] );
 	}
 
 	return $level;
@@ -331,6 +618,88 @@ function pmprodon_pmpro_registration_checks( $continue ) {
 	return $continue;
 }
 add_filter( 'pmpro_registration_checks', 'pmprodon_pmpro_registration_checks' );
+
+/**
+ * Filter checkout page text for donation-only levels.
+ *
+ * Replaces membership-oriented language with donation-appropriate language
+ * when the current checkout level is donation-only. This filter is hooked
+ * on pmpro_checkout_before_form and unhooked on pmpro_checkout_after_form
+ * to limit its scope to the checkout form rendering only.
+ *
+ * @since 2.3
+ *
+ * @param string $translated_text The translated text.
+ * @param string $text            The original (untranslated) text.
+ * @param string $domain          The text domain.
+ * @return string The modified or original text.
+ */
+function pmprodon_filter_donation_only_checkout_text( $translated_text, $text, $domain ) {
+	// Only filter PMPro core strings.
+	if ( $domain !== 'paid-memberships-pro' ) {
+		return $translated_text;
+	}
+
+	global $pmpro_level;
+
+	// Check if this is a donation-only level.
+	if ( empty( $pmpro_level ) || ! pmprodon_is_donations_only( $pmpro_level->id ) ) {
+		return $translated_text;
+	}
+
+	// Map of PMPro core strings to donation-appropriate replacements.
+	switch ( $text ) {
+		case 'Membership Level':
+			return __( 'Donation', 'pmpro-donations' );
+
+		case 'You have selected the <strong>%s</strong> membership level.':
+			/* translators: %s: the level name */
+			return __( 'You are making a donation.', 'pmpro-donations' );
+
+		case 'Submit and Check Out':
+			return __( 'Donate Now', 'pmpro-donations' );
+
+		case 'Submit and Confirm':
+			return __( 'Donate Now', 'pmpro-donations' );
+
+		case 'The price for membership is <strong>%s</strong> now':
+			return '';
+
+		case 'The price for membership is <strong>%s</strong> now and then <strong>%s per %s for %d more %s</strong>.':
+			return '';
+
+		case 'Membership expires after %d %s.':
+			return '';
+
+		case 'Change':
+			return '';
+	}
+
+	return $translated_text;
+}
+
+/**
+ * Hook the donation-only checkout text filter before the checkout form.
+ *
+ * @since 2.3
+ */
+function pmprodon_hook_donation_only_checkout_text() {
+	global $pmpro_level;
+	if ( ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
+		add_filter( 'gettext', 'pmprodon_filter_donation_only_checkout_text', 10, 3 );
+	}
+}
+add_action( 'pmpro_checkout_before_form', 'pmprodon_hook_donation_only_checkout_text' );
+
+/**
+ * Unhook the donation-only checkout text filter after the checkout form.
+ *
+ * @since 2.3
+ */
+function pmprodon_unhook_donation_only_checkout_text() {
+	remove_filter( 'gettext', 'pmprodon_filter_donation_only_checkout_text', 10, 3 );
+}
+add_action( 'pmpro_checkout_after_form', 'pmprodon_unhook_donation_only_checkout_text' );
 
 /**
  * Override level cost text on checkout page
@@ -396,6 +765,19 @@ function pmprodon_pmpro_invoice_bullets_bottom( $order ) {
 			'membership_cost' => '<strong>' . __( 'Membership Cost', 'pmpro-donations' ) . ": </strong> " . pmpro_formatPrice( $components['price'] ),
 			'donation'        => '<strong>' . __( 'Donation', 'pmpro-donations' ) . ": </strong>" . pmpro_formatPrice( $components['donation'] )
 		);
+
+		// Add cover fee if present.
+		$fee_covered = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+		if ( ! empty( $fee_covered ) && (float) $fee_covered > 0 ) {
+			$bullets['fee_covered'] = '<strong>' . esc_html__( 'Processing Fee Covered', 'pmpro-donations' ) . ': </strong>' . pmpro_formatPrice( $fee_covered );
+		}
+
+		// Add donation note if present.
+		$donation_note = get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+		if ( ! empty( $donation_note ) ) {
+			$bullets['donation_note'] = '<strong>' . esc_html__( 'Donation Note', 'pmpro-donations' ) . ': </strong>' . esc_html( $donation_note );
+		}
+
 		$bullets = apply_filters( 'pmpro_donations_invoice_bullets', $bullets, $order );
 		foreach ( $bullets as $bullet ) {
 			echo '<li class="' . esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ) . '">' . wp_kses_post( $bullet ) . '</li>';
@@ -404,6 +786,20 @@ function pmprodon_pmpro_invoice_bullets_bottom( $order ) {
 }
 add_filter( 'pmpro_invoice_bullets_bottom', 'pmprodon_pmpro_invoice_bullets_bottom' );
 
+/**
+ * Add donation-related email template variables.
+ *
+ * Provides !!donation!!, !!donation_note!!, and !!donation_fee_covered!!
+ * email template variables. For donation-only levels, also overrides the
+ * email subject to use donation-appropriate language.
+ *
+ * @since 2.0
+ * @since 2.3 Override email subject for donation-only level checkouts.
+ *
+ * @param array  $data  The email template data.
+ * @param object $email The email object.
+ * @return array The modified email template data.
+ */
 function pmprodon_pmpro_email_data( $data, $email ) {
 	$order_id = empty( $email->data['order_id'] ) ? false : $email->data['order_id'];
 	if ( ! empty( $order_id ) ) {
@@ -411,9 +807,31 @@ function pmprodon_pmpro_email_data( $data, $email ) {
 		$components = pmprodon_get_price_components( $order );
 
 		if ( ! empty( $components['donation'] ) ) {
-			$data['donation'] =  pmpro_formatPrice( $components['donation'] );
+			$data['donation'] = pmpro_formatPrice( $components['donation'] );
 		} else {
-			$data['donation'] =  pmpro_formatPrice( 0 );
+			$data['donation'] = pmpro_formatPrice( 0 );
+		}
+
+		// Add donation note email variable.
+		$donation_note = get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+		$data['donation_note'] = ! empty( $donation_note ) ? esc_html( $donation_note ) : '';
+
+		// Add cover fee email variable.
+		$fee_covered = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+		$data['donation_fee_covered'] = ! empty( $fee_covered ) && (float) $fee_covered > 0 ? pmpro_formatPrice( $fee_covered ) : '';
+
+		// Override subject for donation-only level checkout emails.
+		if ( strpos( $email->template, 'checkout' ) !== false && ! empty( $order->membership_id ) && pmprodon_is_donations_only( $order->membership_id ) ) {
+			if ( strpos( $email->template, 'admin' ) !== false ) {
+				$data['subject'] = sprintf(
+					/* translators: %s: the site name */
+					__( 'Donation received at %s', 'pmpro-donations' ),
+					get_bloginfo( 'name' )
+				);
+			} else {
+				$data['subject'] = __( 'Thank you for your donation', 'pmpro-donations' );
+			}
+			$email->subject = $data['subject'];
 		}
 	}
 	return $data;
@@ -421,23 +839,95 @@ function pmprodon_pmpro_email_data( $data, $email ) {
 add_filter( 'pmpro_email_data', 'pmprodon_pmpro_email_data', 10, 2 );
 
 /**
- * Show order components in confirmation email.
+ * Filter checkout confirmation emails for donation levels.
+ *
+ * For all donation levels: injects donation amount, cover fee, and
+ * donation note before the Invoice section (when not using template variables).
+ *
+ * For donation-only levels: replaces membership language in the email body
+ * with donation-appropriate language (e.g. "membership" → "donation",
+ * "your membership account is now active" → "your donation has been received").
+ *
+ * When a level has an email_template_override setting, the email template
+ * name is swapped before any other processing. Admin emails get the
+ * override name with '_admin' appended. This is compatible with the
+ * pmpro-email-templates add-on for full template editing.
+ *
+ * @since 2.0
+ * @since 2.3 Replace membership language for donation-only level emails.
+ * @since 2.3 Add per-level email template override support.
+ *
+ * @param object $email The email object.
+ * @return object The modified email object.
  */
 function pmprodon_pmpro_email_filter( $email ) {
-	global $wpdb;
+	// Only update confirmation emails.
+	if ( strpos( $email->template, 'checkout' ) === false ) {
+		return $email;
+	}
 
-	// only update confirmation emails which aren't using !!donation!! email variable
-	if ( strpos( $email->template, 'checkout' ) !== false && strpos( $email->body, '!!donation!!' ) === false ) {
-		// get the user_id from the email
-		$order_id = ( empty( $email->data ) || empty( $email->data['order_id'] ) ) ? false : $email->data['order_id'];
-		if ( ! empty( $order_id ) ) {
-			$order      = new MemberOrder( $order_id );
-			$components = pmprodon_get_price_components( $order );
+	$order_id = ( empty( $email->data ) || empty( $email->data['order_id'] ) ) ? false : $email->data['order_id'];
+	if ( empty( $order_id ) ) {
+		return $email;
+	}
 
-			// add to bottom of email
-			if ( ! empty( $components['donation'] ) ) {
-				$email->body = preg_replace( '/\<p\>\s*' . __( 'Invoice', 'pmpro-donations' ) . '/', '<p>' . __( 'Donation Amount:', 'pmpro-donations' ) . '' . pmpro_formatPrice( $components['donation'] ) . '</p><p>' . __( 'Invoice', 'pmpro-donations' ), $email->body );
+	$order = new MemberOrder( $order_id );
+
+	// Swap the email template if the level has a custom override.
+	if ( ! empty( $order->membership_id ) ) {
+		$level_settings = pmprodon_get_level_settings( $order->membership_id );
+		if ( ! empty( $level_settings['email_template_override'] ) ) {
+			$override = sanitize_text_field( $level_settings['email_template_override'] );
+			if ( strpos( $email->template, 'admin' ) !== false ) {
+				$email->template = $override . '_admin';
+			} else {
+				$email->template = $override;
 			}
+		}
+	}
+
+	$components = pmprodon_get_price_components( $order );
+
+	// Inject donation info before Invoice section (when not using !!donation!! variable).
+	if ( ! empty( $components['donation'] ) && strpos( $email->body, '!!donation!!' ) === false ) {
+		$donation_info = __( 'Donation Amount:', 'pmpro-donations' ) . ' ' . pmpro_formatPrice( $components['donation'] );
+
+		// Append cover fee if present and not already using !!donation_fee_covered!! variable.
+		if ( strpos( $email->body, '!!donation_fee_covered!!' ) === false ) {
+			$fee_covered = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+			if ( ! empty( $fee_covered ) && (float) $fee_covered > 0 ) {
+				$donation_info .= '</p><p>' . esc_html__( 'Processing Fee Covered:', 'pmpro-donations' ) . ' ' . pmpro_formatPrice( $fee_covered );
+			}
+		}
+
+		// Append donation note if present and not already using !!donation_note!! variable.
+		if ( strpos( $email->body, '!!donation_note!!' ) === false ) {
+			$donation_note = get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+			if ( ! empty( $donation_note ) ) {
+				$donation_info .= '</p><p>' . esc_html__( 'Donation Note:', 'pmpro-donations' ) . ' ' . esc_html( $donation_note );
+			}
+		}
+
+		$email->body = preg_replace( '/\<p\>\s*' . __( 'Invoice', 'pmpro-donations' ) . '/', '<p>' . $donation_info . '</p><p>' . __( 'Invoice', 'pmpro-donations' ), $email->body );
+	}
+
+	// Replace membership language with donation language for donation-only levels.
+	if ( ! empty( $order->membership_id ) && pmprodon_is_donations_only( $order->membership_id ) ) {
+		// Replace common membership phrases with donation equivalents.
+		$replacements = array(
+			'Your membership account is now active.'     => __( 'Your donation has been received.', 'pmpro-donations' ),
+			'your membership account is now active.'     => __( 'your donation has been received.', 'pmpro-donations' ),
+			'Thank you for your membership'              => __( 'Thank you for your donation', 'pmpro-donations' ),
+			'thank you for your membership'              => __( 'thank you for your donation', 'pmpro-donations' ),
+			'membership level has been changed'          => __( 'donation has been processed', 'pmpro-donations' ),
+			'has changed their membership level'         => __( 'has made a donation', 'pmpro-donations' ),
+			'your membership confirmation'               => __( 'your donation confirmation', 'pmpro-donations' ),
+			'Your membership confirmation'               => __( 'Your donation confirmation', 'pmpro-donations' ),
+			'Membership Level:'                          => __( 'Donation:', 'pmpro-donations' ),
+		);
+
+		foreach ( $replacements as $search => $replace ) {
+			$email->body = str_replace( $search, $replace, $email->body );
 		}
 	}
 
@@ -513,64 +1003,510 @@ function pmprodon_ppe_add_donation_to_request() {
 	if ( ! empty( $donation['donation'] ) && empty( $_REQUEST['donation'] ) ) {
 		$_REQUEST['donation'] = $donation['donation'];
 	}
+
+	// Restore the donation note from order meta for PayPal Express.
+	$donation_note = get_pmpro_membership_order_meta( $order->id, 'donation_note', true );
+	if ( ! empty( $donation_note ) && empty( $_REQUEST['donation_note'] ) ) {
+		$_REQUEST['donation_note'] = $donation_note;
+	}
+
+	// Restore the cover fees flag from order meta for PayPal Express.
+	$fee_covered = get_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', true );
+	if ( ! empty( $fee_covered ) && (float) $fee_covered > 0 && empty( $_REQUEST['cover_fees'] ) ) {
+		$_REQUEST['cover_fees'] = '1';
+	}
 }
 add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmprodon_ppe_add_donation_to_request' );
 
 /**
  * Add donation amount to order meta.
  *
- * @since 2.0
+ * Reads from the global $pmprodon_donation_amount set during
+ * pmprodon_pmpro_checkout_level() as the primary source. Falls back
+ * to $_REQUEST['donation'] for edge cases or non-standard checkout flows.
  *
- * @param int   $user_id The user ID.
- * @param object The order object.
+ * @since 2.0
+ * @since 2.3 Use global donation amount to fix Pay by Check gateway (Issue #86).
+ *            Apply sanitization to prevent whitespace-corrupted values (Issue #89).
+ *
+ * @param int    $user_id The user ID.
+ * @param object $order   The order object.
  */
 function pmprodon_store_donation_amount_in_order_meta( $user_id, $order ) {
-	if ( isset( $_REQUEST['donation'] ) ) {
-		update_pmpro_membership_order_meta( $order->id, 'donation_amount', sanitize_text_field( $_REQUEST['donation'] ) );
+	global $pmprodon_donation_amount;
+
+	// Primary source: global set during pmpro_checkout_level (already sanitized).
+	if ( isset( $pmprodon_donation_amount ) ) {
+		$donation = $pmprodon_donation_amount;
+	} elseif ( isset( $_REQUEST['donation'] ) ) {
+		// Fallback: read from $_REQUEST with full sanitization.
+		$donation = sanitize_text_field( preg_replace( '/[^0-9\.]/', '', trim( $_REQUEST['donation'] ) ) );
+	} else {
+		return;
+	}
+
+	update_pmpro_membership_order_meta( $order->id, 'donation_amount', $donation );
+
+	// Track the last donation date for reminder emails.
+	if ( (float) $donation > 0 && $user_id > 0 ) {
+		update_user_meta( $user_id, 'pmprodon_last_donation_date', current_time( 'timestamp' ) );
+	}
+
+	// Store the cover fee amount in order meta.
+	global $pmprodon_cover_fee_amount;
+	if ( ! empty( $pmprodon_cover_fee_amount ) && $pmprodon_cover_fee_amount > 0 ) {
+		update_pmpro_membership_order_meta( $order->id, 'donation_fee_covered', $pmprodon_cover_fee_amount );
+	}
+
+	// Store the donation note in order meta.
+	global $pmprodon_donation_note;
+	if ( isset( $pmprodon_donation_note ) ) {
+		$donation_note = $pmprodon_donation_note;
+	} elseif ( isset( $_REQUEST['donation_note'] ) ) {
+		$donation_note = sanitize_textarea_field( $_REQUEST['donation_note'] );
+	} else {
+		$donation_note = '';
+	}
+	if ( ! empty( $donation_note ) ) {
+		update_pmpro_membership_order_meta( $order->id, 'donation_note', $donation_note );
 	}
 }
 add_action( 'pmpro_after_checkout', 'pmprodon_store_donation_amount_in_order_meta', 10, 2 );
 
 /**
- * Function to add the donation confirmation message to the confirmation page.
+ * Filter the confirmation page message for donation levels.
  *
- * Note: This does not modify the confirmation message in the email. This would
- * need to be implemented separately.
+ * For donation-only levels, replaces the default PMPro confirmation
+ * message with a donation-specific thank-you message. The custom
+ * confirmation_message level setting is appended after.
+ *
+ * For regular donation levels (donation + membership), appends the
+ * custom confirmation_message after the default PMPro message.
  *
  * @since 2.0
+ * @since 2.3 Replace entire message for donation-only levels.
  *
  * @param string $message The confirmation message.
  * @param object $invoice The MemberOrder object.
- * @return string $message The confirmation message.
+ * @return string The modified confirmation message.
  */
 function pmprodon_pmpro_confirmation_message( $message, $invoice ) {
-	//Get the level ID from the MemberOrder object.
+	// Get the level ID from the MemberOrder object.
 	if ( $invoice ) {
 		$level_id = $invoice->membership_id;
-	//If for some reason we can't find the level ID, try to get it from the URL.
-	 } else if ( isset ( $_REQUEST['pmpro_level'] ) ) {
-		$level_id = $_REQUEST['pmpro_level'];
-	// Backwards compatibility for PMPro 2.x
-	 }  else if ( isset ( $_REQUEST['level'] ) ) { 
-		$level_id = $_REQUEST['level'];
-	//Bail if we can't find the level ID.
+	} elseif ( isset( $_REQUEST['pmpro_level'] ) ) {
+		$level_id = intval( $_REQUEST['pmpro_level'] );
+	} elseif ( isset( $_REQUEST['level'] ) ) {
+		$level_id = intval( $_REQUEST['level'] );
 	} else {
 		return $message;
 	}
 
-	//Bail if not a donation level or donations are not enabled or there is no confirmation message.
+	// Bail if donations are not enabled for this level.
 	$settings = pmprodon_get_level_settings( $level_id );
-	if( ! $settings['donations'] || empty( $settings['confirmation_message'] ) ) {
+	if ( ! $settings['donations'] ) {
 		return $message;
 	}
 
-	//Bail if no donation amount.
+	// For donation-only levels, replace the entire confirmation message.
+	if ( pmprodon_is_donations_only( $level_id ) ) {
+		$donation_message = '';
+
+		// Build the donation thank-you message.
+		if ( $invoice ) {
+			$components = pmprodon_get_price_components( $invoice );
+			if ( ! empty( $components['donation'] ) ) {
+				$donation_message = '<p>' . sprintf(
+					/* translators: %s: the formatted donation amount */
+					esc_html__( 'Thank you for your donation of %s.', 'pmpro-donations' ),
+					pmpro_formatPrice( $components['donation'] )
+				) . '</p>';
+			} else {
+				$donation_message = '<p>' . esc_html__( 'Thank you for your donation.', 'pmpro-donations' ) . '</p>';
+			}
+		} else {
+			$donation_message = '<p>' . esc_html__( 'Thank you for your donation.', 'pmpro-donations' ) . '</p>';
+		}
+
+		// Append the custom confirmation_message setting if configured.
+		if ( ! empty( $settings['confirmation_message'] ) ) {
+			$donation_message .= wpautop( wp_kses_post( $settings['confirmation_message'] ) );
+		}
+
+		return $donation_message;
+	}
+
+	// For regular donation levels, append the custom confirmation_message.
+	if ( empty( $settings['confirmation_message'] ) ) {
+		return $message;
+	}
+
+	// Bail if no donation amount.
 	$components = pmprodon_get_price_components( $invoice );
 	if ( empty( $components['donation'] ) ) {
 		return $message;
 	}
 
-	// Show the donation confirmation message.
 	return $message . wpautop( wp_kses_post( $settings['confirmation_message'] ) );
 }
 add_filter( 'pmpro_confirmation_message', 'pmprodon_pmpro_confirmation_message', 10, 2 );
+
+/**
+ * Bypass PMPro registration checks for guest donor checkouts.
+ *
+ * When a guest checkout is in progress, the username and password fields
+ * are auto-generated by JavaScript. This filter skips PMPro's standard
+ * username/password validation so that auto-generated credentials are accepted.
+ *
+ * @since 2.3
+ *
+ * @param bool $continue Whether registration checks should continue.
+ * @return bool
+ */
+function pmprodon_guest_registration_checks( $continue ) {
+	if ( ! $continue ) {
+		return $continue;
+	}
+
+	if ( ! pmprodon_is_guest_checkout() ) {
+		return $continue;
+	}
+
+	// For guest checkout, validate that we have an email address.
+	if ( empty( $_REQUEST['bemail'] ) ) {
+		global $pmpro_msg, $pmpro_msgt;
+		$pmpro_msg  = __( 'Please enter your email address.', 'pmpro-donations' );
+		$pmpro_msgt = 'pmpro_error';
+		return false;
+	}
+
+	// Validate email format.
+	$email = sanitize_email( $_REQUEST['bemail'] );
+	if ( ! is_email( $email ) ) {
+		global $pmpro_msg, $pmpro_msgt;
+		$pmpro_msg  = __( 'Please enter a valid email address.', 'pmpro-donations' );
+		$pmpro_msgt = 'pmpro_error';
+		return false;
+	}
+
+	// Check if the email belongs to an existing user.
+	$existing_user = get_user_by( 'email', $email );
+	if ( $existing_user ) {
+		// Allow if the existing user is already a guest donor (repeat donation).
+		$is_existing_guest = get_user_meta( $existing_user->ID, 'pmprodon_is_guest_donor', true );
+		if ( empty( $is_existing_guest ) ) {
+			global $pmpro_msg, $pmpro_msgt;
+			$pmpro_msg  = __( 'An account with this email address already exists. Please log in to donate, or use a different email address.', 'pmpro-donations' );
+			$pmpro_msgt = 'pmpro_error';
+			return false;
+		}
+	}
+
+	return $continue;
+}
+add_filter( 'pmpro_registration_checks', 'pmprodon_guest_registration_checks', 5 );
+
+/**
+ * Block guest checkout for levels with recurring billing.
+ *
+ * Runs at pmpro_registration_checks to prevent guest donors from
+ * checking out for subscription-based levels.
+ *
+ * @since 2.3
+ *
+ * @param bool $continue Whether registration checks should continue.
+ * @return bool
+ */
+function pmprodon_block_guest_recurring( $continue ) {
+	if ( ! $continue ) {
+		return $continue;
+	}
+
+	// Only check for guest checkout attempts.
+	if ( is_user_logged_in() || empty( $_REQUEST['pmprodon_guest'] ) || $_REQUEST['pmprodon_guest'] !== '1' ) {
+		return $continue;
+	}
+
+	$level = pmpro_getLevelAtCheckout();
+	if ( ! empty( $level->billing_amount ) && (float) $level->billing_amount > 0 ) {
+		global $pmpro_msg, $pmpro_msgt;
+		$pmpro_msg  = __( 'Guest checkout is only available for one-time donations. Please create an account for recurring donations.', 'pmpro-donations' );
+		$pmpro_msgt = 'pmpro_error';
+		return false;
+	}
+
+	return $continue;
+}
+add_filter( 'pmpro_registration_checks', 'pmprodon_block_guest_recurring', 4 );
+
+/**
+ * Generate guest donor credentials before user creation.
+ *
+ * Intercepts the checkout process for guest donors by setting a random
+ * username and password in $_REQUEST if not already set. This ensures
+ * PMPro's user creation flow works normally with non-loginable credentials.
+ *
+ * @since 2.3
+ */
+function pmprodon_prepare_guest_user_data() {
+	if ( ! pmprodon_is_guest_checkout() ) {
+		return;
+	}
+
+	// Store a global flag so we know this is a guest checkout.
+	global $pmprodon_is_guest_checkout;
+	$pmprodon_is_guest_checkout = true;
+
+	// Generate a unique username if not already auto-generated by JS.
+	if ( empty( $_REQUEST['username'] ) || strpos( $_REQUEST['username'], 'guest_donor_' ) !== 0 ) {
+		$_REQUEST['username'] = 'guest_donor_' . substr( md5( uniqid( wp_rand(), true ) ), 0, 12 );
+	}
+
+	// Generate a strong random password.
+	if ( empty( $_REQUEST['password'] ) || strlen( $_REQUEST['password'] ) < 20 ) {
+		$random_password = wp_generate_password( 32, true, true );
+		$_REQUEST['password']  = $random_password;
+		$_REQUEST['password2'] = $random_password;
+	}
+}
+add_action( 'pmpro_checkout_preheader', 'pmprodon_prepare_guest_user_data', 1 );
+
+/**
+ * Configure a newly registered user as a guest donor.
+ *
+ * Sets the `pmprodon_is_guest_donor` user meta flag, removes all roles
+ * (preventing login), and stores the email for reference.
+ *
+ * @since 2.3
+ *
+ * @param int $user_id The newly registered user ID.
+ */
+function pmprodon_setup_guest_donor_user( $user_id ) {
+	global $pmprodon_is_guest_checkout;
+
+	if ( empty( $pmprodon_is_guest_checkout ) ) {
+		return;
+	}
+
+	// Mark user as a guest donor.
+	update_user_meta( $user_id, 'pmprodon_is_guest_donor', 1 );
+
+	// Remove all roles so the user cannot log in.
+	$user = new WP_User( $user_id );
+	$user->set_role( '' );
+}
+add_action( 'user_register', 'pmprodon_setup_guest_donor_user' );
+
+/**
+ * Store confirmation key in order meta for guest donors.
+ *
+ * Generates a unique confirmation key and saves it to order meta so
+ * that the guest donor can access their confirmation/invoice page
+ * without logging in.
+ *
+ * @since 2.3
+ *
+ * @param int    $user_id The user ID.
+ * @param object $order   The order object.
+ */
+function pmprodon_store_guest_confirmation_key( $user_id, $order ) {
+	// Only store a key for guest donors.
+	$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
+	if ( empty( $is_guest ) ) {
+		return;
+	}
+
+	$confirmation_key = pmprodon_generate_confirmation_key();
+	update_pmpro_membership_order_meta( $order->id, 'pmprodon_confirmation_key', $confirmation_key );
+
+	// Store the guest flag on the order meta for easy lookup.
+	update_pmpro_membership_order_meta( $order->id, 'pmprodon_is_guest_order', 1 );
+
+	// Store the key in a global so it can be used in the email.
+	global $pmprodon_confirmation_key;
+	$pmprodon_confirmation_key = $confirmation_key;
+}
+add_action( 'pmpro_after_checkout', 'pmprodon_store_guest_confirmation_key', 11, 2 );
+
+/**
+ * Filter checkout confirmation emails for guest donors.
+ *
+ * Removes login credentials (username, password, login URL) from the
+ * checkout email body since guest donors don't have loginable accounts.
+ * Adds a confirmation key URL for accessing the invoice.
+ *
+ * @since 2.3
+ *
+ * @param object $email The email object.
+ * @return object The modified email object.
+ */
+function pmprodon_filter_guest_donor_email( $email ) {
+	// Only filter checkout emails.
+	if ( strpos( $email->template, 'checkout' ) === false ) {
+		return $email;
+	}
+
+	// Check if this is a guest donor order.
+	$order_id = ( empty( $email->data ) || empty( $email->data['order_id'] ) ) ? false : $email->data['order_id'];
+	if ( empty( $order_id ) ) {
+		return $email;
+	}
+
+	$is_guest_order = get_pmpro_membership_order_meta( $order_id, 'pmprodon_is_guest_order', true );
+	if ( empty( $is_guest_order ) ) {
+		return $email;
+	}
+
+	// Strip login-related content from the email body.
+	// Remove lines containing username, password, and login URL.
+	$patterns = array(
+		'/^.*' . preg_quote( '!!username!!', '/' ) . '.*$/m',
+		'/^.*' . preg_quote( '!!password!!', '/' ) . '.*$/m',
+		'/^.*' . preg_quote( '!!login_url!!', '/' ) . '.*$/m',
+		'/^.*' . preg_quote( '!!login_link!!', '/' ) . '.*$/m',
+	);
+	$email->body = preg_replace( $patterns, '', $email->body );
+
+	// Clean up consecutive blank lines left after stripping.
+	$email->body = preg_replace( '/(\r?\n){3,}/', "\n\n", $email->body );
+
+	// Add confirmation key URL if available.
+	$confirmation_key = get_pmpro_membership_order_meta( $order_id, 'pmprodon_confirmation_key', true );
+	if ( ! empty( $confirmation_key ) ) {
+		$confirmation_url = add_query_arg( 'pmprodon_key', $confirmation_key, pmpro_url( 'confirmation' ) );
+		$confirmation_link = '<p>' . sprintf(
+			/* translators: %s: the confirmation page URL */
+			esc_html__( 'View your donation confirmation: %s', 'pmpro-donations' ),
+			'<a href="' . esc_url( $confirmation_url ) . '">' . esc_html( $confirmation_url ) . '</a>'
+		) . '</p>';
+
+		// Insert the confirmation link before the Invoice section, or at the end.
+		if ( strpos( $email->body, __( 'Invoice', 'pmpro-donations' ) ) !== false ) {
+			$email->body = preg_replace(
+				'/\<p\>\s*' . preg_quote( __( 'Invoice', 'pmpro-donations' ), '/' ) . '/',
+				$confirmation_link . '<p>' . __( 'Invoice', 'pmpro-donations' ),
+				$email->body
+			);
+		} else {
+			$email->body .= $confirmation_link;
+		}
+	}
+
+	return $email;
+}
+add_filter( 'pmpro_email_filter', 'pmprodon_filter_guest_donor_email', 5, 2 );
+
+/**
+ * Handle confirmation key access for guest donors.
+ *
+ * Allows unauthenticated visitors to view their donation confirmation
+ * page by passing a valid `pmprodon_key` query parameter. The key is
+ * validated against order meta. If valid, the matching order is loaded
+ * into the global context for the confirmation template.
+ *
+ * @since 2.3
+ */
+function pmprodon_handle_confirmation_key_access() {
+	// Only act on the confirmation page.
+	if ( ! function_exists( 'pmpro_is_page' ) || ! pmpro_is_page( 'confirmation' ) ) {
+		return;
+	}
+
+	// Only needed for non-logged-in users.
+	if ( is_user_logged_in() ) {
+		return;
+	}
+
+	// Check for confirmation key.
+	if ( empty( $_REQUEST['pmprodon_key'] ) ) {
+		return;
+	}
+
+	$key = sanitize_text_field( $_REQUEST['pmprodon_key'] );
+	if ( strlen( $key ) !== 32 ) {
+		return;
+	}
+
+	// Look up the order with this confirmation key.
+	global $wpdb;
+	$order_id = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT pmpro_membership_order_id FROM {$wpdb->prefix}pmpro_membership_ordermeta WHERE meta_key = 'pmprodon_confirmation_key' AND meta_value = %s LIMIT 1",
+			$key
+		)
+	);
+
+	if ( empty( $order_id ) ) {
+		return;
+	}
+
+	// Verify this is a guest order.
+	$is_guest = get_pmpro_membership_order_meta( $order_id, 'pmprodon_is_guest_order', true );
+	if ( empty( $is_guest ) ) {
+		return;
+	}
+
+	// Load the order and set up the global for the confirmation template.
+	$order = new MemberOrder( $order_id );
+	if ( empty( $order->id ) ) {
+		return;
+	}
+
+	// Set the current user temporarily so PMPro's confirmation page works.
+	global $current_user, $pmpro_invoice;
+	$pmpro_invoice = $order;
+
+	// Temporarily log in as the guest user for this page view only.
+	wp_set_current_user( $order->user_id );
+}
+add_action( 'template_redirect', 'pmprodon_handle_confirmation_key_access', 1 );
+
+/**
+ * Restore guest checkout state for PayPal Express redirect flow.
+ *
+ * When PayPal Express redirects back to the site, this function
+ * restores the guest checkout flag from the order meta so the
+ * checkout can complete as a guest donation.
+ *
+ * @since 2.3
+ */
+function pmprodon_ppe_restore_guest_state() {
+	// Check if the "review" or "confirm" request variables are set.
+	if ( empty( $_REQUEST['review'] ) && empty( $_REQUEST['confirm'] ) ) {
+		return;
+	}
+
+	// Check if we have a PPE token that we are reviewing.
+	if ( empty( $_REQUEST['token'] ) ) {
+		return;
+	}
+	$token = sanitize_text_field( $_REQUEST['token'] );
+
+	// Make sure that the MemberOrder class is loaded.
+	if ( ! class_exists( 'MemberOrder' ) ) {
+		return;
+	}
+
+	// Check if we have an order with this token.
+	$order = new MemberOrder();
+	$order->getMemberOrderByPayPalToken( $token );
+	if ( empty( $order->id ) ) {
+		return;
+	}
+
+	// Check if this is a guest order.
+	$is_guest = get_pmpro_membership_order_meta( $order->id, 'pmprodon_is_guest_order', true );
+	if ( empty( $is_guest ) ) {
+		return;
+	}
+
+	// Restore the guest checkout flag.
+	if ( empty( $_REQUEST['pmprodon_guest'] ) ) {
+		$_REQUEST['pmprodon_guest'] = '1';
+	}
+
+	// Set the global flag.
+	global $pmprodon_is_guest_checkout;
+	$pmprodon_is_guest_checkout = true;
+}
+add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmprodon_ppe_restore_guest_state', 5 );

--- a/includes/common.php
+++ b/includes/common.php
@@ -52,13 +52,22 @@ function pmprodon_getPriceComponents( $order ) {
  */
 function pmprodon_get_level_settings( $level_id ) {
 	$default_settings = array(
-		'donations'       => 0,
-		'donations_only'  => 0,
-		'min_price'       => '',
-		'max_price'       => '',
-		'dropdown_prices' => '',
-		'text'            => '',
-		'confirmation_message' => '',
+		'donations'              => 0,
+		'donations_only'         => 0,
+		'allow_guest_donations'  => 0,
+		'min_price'              => '',
+		'max_price'              => '',
+		'dropdown_prices'        => '',
+		'display_mode'           => 'dropdown',
+		'text'                   => '',
+		'confirmation_message'   => '',
+		'donation_note_enabled'  => 0,
+		'donation_note_label'    => '',
+		'cover_fees_enabled'     => 0,
+		'cover_fees_percentage'  => '2.9',
+		'cover_fees_flat'        => '0.30',
+		'reminder_interval'           => 'none',
+		'email_template_override'     => '',
 	);
 	
 	if ( $level_id > 0 ) {
@@ -76,4 +85,84 @@ function pmprodon_get_level_settings( $level_id ) {
 function pmprodon_is_donations_only( $level_id ) {
 	$settings = pmprodon_get_level_settings( $level_id );
 	return $settings['donations'] && $settings['donations_only'];
+}
+
+/**
+ * Calculate the cover fee amount for a given donation.
+ *
+ * Uses the pass-through formula so the organization receives the
+ * full intended donation after the gateway deducts its fees:
+ *   fee = ( donation + flat ) / ( 1 - percentage / 100 ) - donation
+ *
+ * @since 2.3
+ *
+ * @param float $donation   The donation amount.
+ * @param float $percentage The gateway fee percentage (e.g. 2.9).
+ * @param float $flat       The gateway flat fee (e.g. 0.30).
+ * @return float The calculated cover fee, rounded to 2 decimal places.
+ */
+function pmprodon_calculate_cover_fee( $donation, $percentage, $flat ) {
+	$donation   = (float) $donation;
+	$percentage = (float) $percentage;
+	$flat       = (float) $flat;
+
+	if ( $donation <= 0 || $percentage >= 100 ) {
+		return 0.00;
+	}
+
+	$fee = ( $donation + $flat ) / ( 1 - $percentage / 100 ) - $donation;
+
+	return round( $fee, 2 );
+}
+
+/**
+ * Check if the current checkout is a guest donation checkout.
+ *
+ * Returns true when the user is not logged in, the level allows guest
+ * donations, the level is donation-only, and the guest flag is set
+ * in the request.
+ *
+ * @since 2.3
+ *
+ * @return bool Whether this is a guest donation checkout.
+ */
+function pmprodon_is_guest_checkout() {
+	// Logged-in users never use guest checkout.
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+
+	// Check for the guest flag in the request.
+	if ( empty( $_REQUEST['pmprodon_guest'] ) || $_REQUEST['pmprodon_guest'] !== '1' ) {
+		return false;
+	}
+
+	// Get the level at checkout.
+	if ( ! function_exists( 'pmpro_getLevelAtCheckout' ) ) {
+		return false;
+	}
+
+	$level = pmpro_getLevelAtCheckout();
+	if ( empty( $level->id ) ) {
+		return false;
+	}
+
+	// Level must be donation-only with guest donations enabled.
+	$settings = pmprodon_get_level_settings( $level->id );
+	if ( empty( $settings['donations'] ) || empty( $settings['donations_only'] ) || empty( $settings['allow_guest_donations'] ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Generate a unique confirmation key for guest donor order access.
+ *
+ * @since 2.3
+ *
+ * @return string A 32-character random alphanumeric string.
+ */
+function pmprodon_generate_confirmation_key() {
+	return wp_generate_password( 32, false );
 }

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -8,14 +8,23 @@
 
 /**
  * Set existing member flag before checkout.
+ * Store user's previous levels and prevent cancellation when checking out for a donation-only level.
+ *
+ * @since 2.3
+ *
+ * @param int    $user_id The user ID.
+ * @param object $morder  The membership order object.
  */
 function pmprodon_pmpro_checkout_before_change_membership_level( $user_id, $morder ) {
 	global $pmprodon_existing_member_flag, $pmpro_level;
 
-	if ( pmpro_hasMembershipLevel()
-	&& pmpro_is_checkout()
-	&& ! empty( $pmpro_level )
-	&& pmprodon_is_donations_only( $pmpro_level->id ) ) {
+	if ( pmpro_hasMembershipLevel() && pmpro_is_checkout() && ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
+		// Store the user's current level info before it gets changed.
+		$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+		if ( ! empty( $current_levels ) ) {
+			update_user_meta( $user_id, 'pmprodon_previous_levels', $current_levels );
+		}
+
 		add_filter( 'pmpro_cancel_previous_subscriptions', '__return_false' );
 		add_filter( 'pmpro_deactivate_old_levels', '__return_false' );
 		$pmprodon_existing_member_flag = true;
@@ -25,20 +34,97 @@ add_action( 'pmpro_checkout_before_change_membership_level', 'pmprodon_pmpro_che
 
 /**
  * Give existing users their old level back after checkout.
+ * Uses PMPro API to detect donation-only level assignment, then restores
+ * the correct previous level respecting level groups.
+ *
+ * @since 2.3
+ *
+ * @param int $user_id The user ID.
  */
 function pmprodon_pmpro_after_checkout( $user_id ) {
-	global $wpdb, $pmprodon_existing_member_flag, $pmpro_level;
+	global $pmprodon_existing_member_flag;
 
-	if ( isset( $pmprodon_existing_member_flag ) ) {
-		// Remove last row added to members_users table.
-		$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . esc_sql( $user_id ) . "' AND membership_id = '" . esc_sql( $pmpro_level->id ) . "' ORDER BY id DESC LIMIT 1";
-		$wpdb->query( $sqlQuery );
-
-		// Reset user.
-		global $all_membership_levels;
-		unset( $all_membership_levels[ $user_id ] );
-		pmpro_set_current_user();
+	if ( ! isset( $pmprodon_existing_member_flag ) ) {
+		return;
 	}
+
+	// Get user's current levels.
+	$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+
+	// Check if they now have a donation-only level.
+	$donation_level_id = null;
+	$has_donation_level = false;
+
+	foreach ( $current_levels as $level ) {
+		if ( pmprodon_is_donations_only( $level->id ) ) {
+			$donation_level_id = $level->id;
+			$has_donation_level = true;
+			break;
+		}
+	}
+
+	// If user has a donation-only level, restore their previous level.
+	if ( $has_donation_level ) {
+		// Get their previous levels that we stored.
+		$previous_levels = get_user_meta( $user_id, 'pmprodon_previous_levels', true );
+
+		if ( ! empty( $previous_levels ) ) {
+			// Determine which level we should restore.
+			$level_to_restore = null;
+
+			// Find a level from the same group as the donation level.
+			$donation_group_id = null;
+			if ( function_exists( 'pmpro_get_group_id_for_level' ) ) {
+				$donation_group_id = pmpro_get_group_id_for_level( $donation_level_id );
+			}
+
+			if ( $donation_group_id ) {
+				// Find a previous level in the same group.
+				foreach ( $previous_levels as $prev_level ) {
+					$prev_level_group_id = pmpro_get_group_id_for_level( $prev_level->id );
+					if ( $prev_level_group_id === $donation_group_id ) {
+						$level_to_restore = $prev_level;
+						break;
+					}
+				}
+			}
+
+			// If no level found in the same group, use the first previous level.
+			if ( ! $level_to_restore ) {
+				$level_to_restore = $previous_levels[0];
+			}
+
+			// Cancel the donation-only level properly.
+			pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
+
+			// Create a custom level array for restoration.
+			$custom_level = array(
+				'user_id'         => $user_id,
+				'membership_id'   => $level_to_restore->id,
+				'code_id'         => $level_to_restore->code_id,
+				'initial_payment' => $level_to_restore->initial_payment,
+				'billing_amount'  => $level_to_restore->billing_amount,
+				'cycle_number'    => $level_to_restore->cycle_number,
+				'cycle_period'    => $level_to_restore->cycle_period,
+				'billing_limit'   => $level_to_restore->billing_limit,
+				'trial_amount'    => $level_to_restore->trial_amount,
+				'trial_limit'     => $level_to_restore->trial_limit,
+				'startdate'       => $level_to_restore->startdate,
+				'enddate'         => $level_to_restore->enddate,
+			);
+
+			// Restore the original level.
+			pmpro_changeMembershipLevel( $custom_level, $user_id );
+		}
+	}
+
+	// Always clean up stored meta when existing member flag was set.
+	delete_user_meta( $user_id, 'pmprodon_previous_levels' );
+
+	// Reset user.
+	global $all_membership_levels;
+	unset( $all_membership_levels[ $user_id ] );
+	pmpro_set_current_user();
 }
 add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
 
@@ -47,8 +133,8 @@ add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
  *
  * @since 1.1.2
  *
- * @param bool $return
- * @param object $level
+ * @param bool   $return Whether the level is expiring soon.
+ * @param object $level  The level object.
  * @return bool
  */
 function pmprodon_pmpro_is_level_expiring_soon( $return, $level ) {
@@ -59,3 +145,37 @@ function pmprodon_pmpro_is_level_expiring_soon( $return, $level ) {
 	return $return;
 }
 add_filter( 'pmpro_is_level_expiring_soon', 'pmprodon_pmpro_is_level_expiring_soon', 10, 2 );
+
+/**
+ * Filter the text that says a level will be removed at checkout.
+ * Suppresses the misleading 'Your current membership level will be removed' message
+ * when checking out for a donation-only level.
+ *
+ * @since 2.3
+ *
+ * @param string $translated_text The translated text.
+ * @param string $text            The original text.
+ * @param string $domain          The text domain.
+ * @return string The modified or original text.
+ */
+function pmprodon_filter_checkout_level_change_text( $translated_text, $text, $domain ) {
+	// Only proceed if we're on the checkout page.
+	if ( ! pmpro_is_checkout() ) {
+		return $translated_text;
+	}
+
+	// Target only the specific message about level removal.
+	if ( $domain === 'paid-memberships-pro' &&
+		$text === 'Your current membership level of %s will be removed when you complete your purchase.' ) {
+
+		global $pmpro_level;
+
+		// Check if this is a donation-only level.
+		if ( ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
+			return '';
+		}
+	}
+
+	return $translated_text;
+}
+add_filter( 'gettext', 'pmprodon_filter_checkout_level_change_text', 10, 3 );

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -18,6 +18,12 @@
 function pmprodon_pmpro_checkout_before_change_membership_level( $user_id, $morder ) {
 	global $pmprodon_existing_member_flag, $pmpro_level;
 
+	// Skip level preservation for guest donors — they have no existing levels.
+	$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
+	if ( ! empty( $is_guest ) ) {
+		return;
+	}
+
 	if ( pmpro_hasMembershipLevel() && pmpro_is_checkout() && ! empty( $pmpro_level ) && pmprodon_is_donations_only( $pmpro_level->id ) ) {
 		// Store the user's current level info before it gets changed.
 		$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
@@ -37,6 +43,9 @@ add_action( 'pmpro_checkout_before_change_membership_level', 'pmprodon_pmpro_che
  * Uses PMPro API to detect donation-only level assignment, then restores
  * the correct previous level respecting level groups.
  *
+ * For non-members (new users with no prior levels), cancels the donation-only
+ * level so it does not persist on the account page.
+ *
  * @since 2.3
  *
  * @param int $user_id The user ID.
@@ -44,89 +53,131 @@ add_action( 'pmpro_checkout_before_change_membership_level', 'pmprodon_pmpro_che
 function pmprodon_pmpro_after_checkout( $user_id ) {
 	global $pmprodon_existing_member_flag;
 
-	if ( ! isset( $pmprodon_existing_member_flag ) ) {
+	// Skip level restoration for guest donors — they have no previous levels.
+	$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
+	if ( ! empty( $is_guest ) ) {
+		// Guest donors should not retain a donation-only level either.
+		pmprodon_cancel_donation_only_level_for_user( $user_id );
 		return;
 	}
 
-	// Get user's current levels.
-	$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+	// Handle existing members — restore their previous level.
+	if ( isset( $pmprodon_existing_member_flag ) ) {
+		// Get user's current levels.
+		$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
 
-	// Check if they now have a donation-only level.
-	$donation_level_id = null;
-	$has_donation_level = false;
+		// Check if they now have a donation-only level.
+		$donation_level_id  = null;
+		$has_donation_level = false;
+
+		foreach ( $current_levels as $level ) {
+			if ( pmprodon_is_donations_only( $level->id ) ) {
+				$donation_level_id  = $level->id;
+				$has_donation_level = true;
+				break;
+			}
+		}
+
+		// If user has a donation-only level, restore their previous level.
+		if ( $has_donation_level ) {
+			// Get their previous levels that we stored.
+			$previous_levels = get_user_meta( $user_id, 'pmprodon_previous_levels', true );
+
+			if ( ! empty( $previous_levels ) ) {
+				// Determine which level we should restore.
+				$level_to_restore = null;
+
+				// Find a level from the same group as the donation level.
+				$donation_group_id = null;
+				if ( function_exists( 'pmpro_get_group_id_for_level' ) ) {
+					$donation_group_id = pmpro_get_group_id_for_level( $donation_level_id );
+				}
+
+				if ( $donation_group_id ) {
+					// Find a previous level in the same group.
+					foreach ( $previous_levels as $prev_level ) {
+						$prev_level_group_id = pmpro_get_group_id_for_level( $prev_level->id );
+						if ( $prev_level_group_id === $donation_group_id ) {
+							$level_to_restore = $prev_level;
+							break;
+						}
+					}
+				}
+
+				// If no level found in the same group, use the first previous level.
+				if ( ! $level_to_restore ) {
+					$level_to_restore = $previous_levels[0];
+				}
+
+				// Cancel the donation-only level properly.
+				pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
+
+				// Create a custom level array for restoration.
+				$custom_level = array(
+					'user_id'         => $user_id,
+					'membership_id'   => $level_to_restore->id,
+					'code_id'         => $level_to_restore->code_id,
+					'initial_payment' => $level_to_restore->initial_payment,
+					'billing_amount'  => $level_to_restore->billing_amount,
+					'cycle_number'    => $level_to_restore->cycle_number,
+					'cycle_period'    => $level_to_restore->cycle_period,
+					'billing_limit'   => $level_to_restore->billing_limit,
+					'trial_amount'    => $level_to_restore->trial_amount,
+					'trial_limit'     => $level_to_restore->trial_limit,
+					'startdate'       => $level_to_restore->startdate,
+					'enddate'         => $level_to_restore->enddate,
+				);
+
+				// Restore the original level.
+				pmpro_changeMembershipLevel( $custom_level, $user_id );
+			}
+		}
+
+		// Always clean up stored meta when existing member flag was set.
+		delete_user_meta( $user_id, 'pmprodon_previous_levels' );
+
+		// Reset user.
+		global $all_membership_levels;
+		unset( $all_membership_levels[ $user_id ] );
+		pmpro_set_current_user();
+
+		return;
+	}
+
+	// Handle non-members — cancel the donation-only level so it does not
+	// persist on the account page. This user had no prior membership.
+	pmprodon_cancel_donation_only_level_for_user( $user_id );
+}
+add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
+
+/**
+ * Cancel any donation-only level for a user.
+ *
+ * Used after checkout for non-members and guest donors so that the
+ * donation-only level does not persist on the account page.
+ *
+ * @since 2.3
+ *
+ * @param int $user_id The user ID.
+ */
+function pmprodon_cancel_donation_only_level_for_user( $user_id ) {
+	$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+	if ( empty( $current_levels ) ) {
+		return;
+	}
 
 	foreach ( $current_levels as $level ) {
 		if ( pmprodon_is_donations_only( $level->id ) ) {
-			$donation_level_id = $level->id;
-			$has_donation_level = true;
+			pmpro_cancelMembershipLevel( $level->id, $user_id, 'inactive' );
+
+			// Reset user cache.
+			global $all_membership_levels;
+			unset( $all_membership_levels[ $user_id ] );
+			pmpro_set_current_user();
 			break;
 		}
 	}
-
-	// If user has a donation-only level, restore their previous level.
-	if ( $has_donation_level ) {
-		// Get their previous levels that we stored.
-		$previous_levels = get_user_meta( $user_id, 'pmprodon_previous_levels', true );
-
-		if ( ! empty( $previous_levels ) ) {
-			// Determine which level we should restore.
-			$level_to_restore = null;
-
-			// Find a level from the same group as the donation level.
-			$donation_group_id = null;
-			if ( function_exists( 'pmpro_get_group_id_for_level' ) ) {
-				$donation_group_id = pmpro_get_group_id_for_level( $donation_level_id );
-			}
-
-			if ( $donation_group_id ) {
-				// Find a previous level in the same group.
-				foreach ( $previous_levels as $prev_level ) {
-					$prev_level_group_id = pmpro_get_group_id_for_level( $prev_level->id );
-					if ( $prev_level_group_id === $donation_group_id ) {
-						$level_to_restore = $prev_level;
-						break;
-					}
-				}
-			}
-
-			// If no level found in the same group, use the first previous level.
-			if ( ! $level_to_restore ) {
-				$level_to_restore = $previous_levels[0];
-			}
-
-			// Cancel the donation-only level properly.
-			pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
-
-			// Create a custom level array for restoration.
-			$custom_level = array(
-				'user_id'         => $user_id,
-				'membership_id'   => $level_to_restore->id,
-				'code_id'         => $level_to_restore->code_id,
-				'initial_payment' => $level_to_restore->initial_payment,
-				'billing_amount'  => $level_to_restore->billing_amount,
-				'cycle_number'    => $level_to_restore->cycle_number,
-				'cycle_period'    => $level_to_restore->cycle_period,
-				'billing_limit'   => $level_to_restore->billing_limit,
-				'trial_amount'    => $level_to_restore->trial_amount,
-				'trial_limit'     => $level_to_restore->trial_limit,
-				'startdate'       => $level_to_restore->startdate,
-				'enddate'         => $level_to_restore->enddate,
-			);
-
-			// Restore the original level.
-			pmpro_changeMembershipLevel( $custom_level, $user_id );
-		}
-	}
-
-	// Always clean up stored meta when existing member flag was set.
-	delete_user_meta( $user_id, 'pmprodon_previous_levels' );
-
-	// Reset user.
-	global $all_membership_levels;
-	unset( $all_membership_levels[ $user_id ] );
-	pmpro_set_current_user();
 }
-add_action( 'pmpro_after_checkout', 'pmprodon_pmpro_after_checkout' );
 
 /**
  * On the edit level page, we never want to prevent a user from selecting a donation-only level.

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -116,27 +116,30 @@ function pmprodon_pmpro_after_checkout( $user_id ) {
 
 				pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
 
-				// Create a custom level array for restoration.
-				$custom_level = array(
-					'user_id'         => $user_id,
-					'membership_id'   => $level_to_restore->id,
-					'code_id'         => $level_to_restore->code_id,
-					'initial_payment' => $level_to_restore->initial_payment,
-					'billing_amount'  => $level_to_restore->billing_amount,
-					'cycle_number'    => $level_to_restore->cycle_number,
-					'cycle_period'    => $level_to_restore->cycle_period,
-					'billing_limit'   => $level_to_restore->billing_limit,
-					'trial_amount'    => $level_to_restore->trial_amount,
-					'trial_limit'     => $level_to_restore->trial_limit,
-					'startdate'       => $level_to_restore->startdate,
-					'enddate'         => $level_to_restore->enddate,
-				);
+					$current_levels = pmpro_getMembershipLevelsForUser( $user_id );
+					if ( ! pmprodon_user_has_level( $current_levels, $level_to_restore->id ) ) {
+						// Create a custom level array for restoration.
+						$custom_level = array(
+							'user_id'         => $user_id,
+							'membership_id'   => $level_to_restore->id,
+							'code_id'         => $level_to_restore->code_id,
+							'initial_payment' => $level_to_restore->initial_payment,
+							'billing_amount'  => $level_to_restore->billing_amount,
+							'cycle_number'    => $level_to_restore->cycle_number,
+							'cycle_period'    => $level_to_restore->cycle_period,
+							'billing_limit'   => $level_to_restore->billing_limit,
+							'trial_amount'    => $level_to_restore->trial_amount,
+							'trial_limit'     => $level_to_restore->trial_limit,
+							'startdate'       => $level_to_restore->startdate,
+							'enddate'         => $level_to_restore->enddate,
+						);
 
-				// Restore the original level.
-				$restored = pmpro_changeMembershipLevel( $custom_level, $user_id );
-				if ( ! $restored ) {
-					error_log( sprintf( 'PMPro Donations: Failed to restore level %d for user %d after donation-only checkout.', $level_to_restore->id, $user_id ) );
-				}
+						// Restore the original level.
+						$restored = pmpro_changeMembershipLevel( $custom_level, $user_id );
+						if ( ! $restored ) {
+							error_log( sprintf( 'PMPro Donations: Failed to restore level %d for user %d after donation-only checkout.', $level_to_restore->id, $user_id ) );
+						}
+					}
 
 				// Re-enable cancellation emails.
 				remove_filter( 'pmpro_send_cancel_admin_email', '__return_false' );
@@ -192,6 +195,29 @@ function pmprodon_cancel_donation_only_level_for_user( $user_id ) {
 			break;
 		}
 	}
+}
+
+/**
+ * Check whether a level ID is present in a user's current levels.
+ *
+ * @since 2.3
+ *
+ * @param array $levels   Array of level objects.
+ * @param int   $level_id Level ID to check.
+ * @return bool
+ */
+function pmprodon_user_has_level( $levels, $level_id ) {
+	if ( empty( $levels ) ) {
+		return false;
+	}
+
+	foreach ( $levels as $level ) {
+		if ( ! empty( $level->id ) && intval( $level->id ) === intval( $level_id ) ) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/includes/donation-only-level.php
+++ b/includes/donation-only-level.php
@@ -110,6 +110,10 @@ function pmprodon_pmpro_after_checkout( $user_id ) {
 				}
 
 				// Cancel the donation-only level properly.
+				// Suppress cancellation emails during level swap.
+				add_filter( 'pmpro_send_cancel_admin_email', '__return_false' );
+				add_filter( 'pmpro_email_filter', 'pmprodon_suppress_cancellation_email', 1 );
+
 				pmpro_cancelMembershipLevel( $donation_level_id, $user_id, 'inactive' );
 
 				// Create a custom level array for restoration.
@@ -129,7 +133,14 @@ function pmprodon_pmpro_after_checkout( $user_id ) {
 				);
 
 				// Restore the original level.
-				pmpro_changeMembershipLevel( $custom_level, $user_id );
+				$restored = pmpro_changeMembershipLevel( $custom_level, $user_id );
+				if ( ! $restored ) {
+					error_log( sprintf( 'PMPro Donations: Failed to restore level %d for user %d after donation-only checkout.', $level_to_restore->id, $user_id ) );
+				}
+
+				// Re-enable cancellation emails.
+				remove_filter( 'pmpro_send_cancel_admin_email', '__return_false' );
+				remove_filter( 'pmpro_email_filter', 'pmprodon_suppress_cancellation_email', 1 );
 			}
 		}
 
@@ -168,7 +179,11 @@ function pmprodon_cancel_donation_only_level_for_user( $user_id ) {
 
 	foreach ( $current_levels as $level ) {
 		if ( pmprodon_is_donations_only( $level->id ) ) {
+			add_filter( 'pmpro_send_cancel_admin_email', '__return_false' );
+			add_filter( 'pmpro_email_filter', 'pmprodon_suppress_cancellation_email', 1 );
 			pmpro_cancelMembershipLevel( $level->id, $user_id, 'inactive' );
+			remove_filter( 'pmpro_send_cancel_admin_email', '__return_false' );
+			remove_filter( 'pmpro_email_filter', 'pmprodon_suppress_cancellation_email', 1 );
 
 			// Reset user cache.
 			global $all_membership_levels;
@@ -230,3 +245,22 @@ function pmprodon_filter_checkout_level_change_text( $translated_text, $text, $d
 	return $translated_text;
 }
 add_filter( 'gettext', 'pmprodon_filter_checkout_level_change_text', 10, 3 );
+
+/**
+ * Suppress cancellation emails during donation-only level swaps.
+ *
+ * Hooked temporarily at priority 1 on pmpro_email_filter to block
+ * cancellation emails that would confuse donors during the
+ * cancel-and-restore flow.
+ *
+ * @since 2.3
+ *
+ * @param object $email The email object.
+ * @return object The email object, with send disabled if it's a cancellation email.
+ */
+function pmprodon_suppress_cancellation_email( $email ) {
+	if ( strpos( $email->template, 'cancel' ) !== false ) {
+		$email->send = false;
+	}
+	return $email;
+}

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -160,23 +160,6 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 
 <script>
 	jQuery(document).ready(function($) {
-		//toggle fields based on checkbox
-		const toggleDonFields = () => {
-			const $donCheckBox = $('#donations');
-			const $trs = $('.donations-settings-table tbody tr');
-			if($donCheckBox.is(':checked')) {
-				$trs.show();
-			} else {
-				$trs.hide();
-			}
-			$donCheckBox.closest('tr').show();
-		};
-		toggleDonFields();
-		//toggle fields when checkbox state changes
-		$('#donations').on('change', function() {
-			toggleDonFields();
-		});
-
 		//toggle guest donations row based on donations_only checkbox
 		const toggleGuestDonations = () => {
 			if($('#donations_only').is(':checked')) {
@@ -229,6 +212,28 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 		toggleCoverFees();
 		$('#cover_fees_enabled').on('change', function() {
 			toggleCoverFees();
+		});
+
+		//toggle fields based on main donations checkbox
+		const toggleDonFields = () => {
+			const $donCheckBox = $('#donations');
+			const $trs = $('.donations-settings-table tbody tr');
+			if($donCheckBox.is(':checked')) {
+				$trs.show();
+				// Re-apply conditional sub-toggles so dependent rows
+				// respect their own checkbox/field state.
+				toggleGuestDonations();
+				toggleDisplayMode();
+				toggleNoteLabel();
+				toggleCoverFees();
+			} else {
+				$trs.hide();
+			}
+			$donCheckBox.closest('tr').show();
+		};
+		toggleDonFields();
+		$('#donations').on('change', function() {
+			toggleDonFields();
 		});
 	});
 </script>

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -6,13 +6,22 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 	global $pmpro_currency_symbol;
 	$level_id = intval( $_REQUEST['edit'] );
 	$donfields       = pmprodon_get_level_settings( $level_id );			
-	$donations       = ( ! isset( $donfields['donations'] ) ) ? 0 : $donfields['donations'];
-	$donations_only  = ( ! isset( $donfields['donations_only'] ) ) ? 0 : $donfields['donations_only'];
-	$min_price       = ( ! isset( $donfields['min_price'] ) ) ? '' : $donfields['min_price'];
+	$donations              = ( ! isset( $donfields['donations'] ) ) ? 0 : $donfields['donations'];
+	$donations_only         = ( ! isset( $donfields['donations_only'] ) ) ? 0 : $donfields['donations_only'];
+	$allow_guest_donations  = ( ! isset( $donfields['allow_guest_donations'] ) ) ? 0 : $donfields['allow_guest_donations'];
+	$min_price              = ( ! isset( $donfields['min_price'] ) ) ? '' : $donfields['min_price'];
 	$max_price       = ( ! isset( $donfields['max_price'] ) ) ? '' : $donfields['max_price'];
 	$donations_text  = ( ! isset( $donfields['text'] ) ) ? '' : $donfields['text'];
-	$confirmation_message = ( ! isset( $donfields['confirmation_message'] ) ) ? '' : $donfields['confirmation_message'];
-	$dropdown_prices = ( ! isset( $donfields['dropdown_prices'] ) ) ? '' : $donfields['dropdown_prices'];
+	$confirmation_message    = ( ! isset( $donfields['confirmation_message'] ) ) ? '' : $donfields['confirmation_message'];
+	$dropdown_prices         = ( ! isset( $donfields['dropdown_prices'] ) ) ? '' : $donfields['dropdown_prices'];
+	$display_mode            = ( ! isset( $donfields['display_mode'] ) ) ? 'dropdown' : $donfields['display_mode'];
+	$donation_note_enabled   = ( ! isset( $donfields['donation_note_enabled'] ) ) ? 0 : $donfields['donation_note_enabled'];
+	$donation_note_label     = ( ! isset( $donfields['donation_note_label'] ) ) ? '' : $donfields['donation_note_label'];
+	$cover_fees_enabled      = ( ! isset( $donfields['cover_fees_enabled'] ) ) ? 0 : $donfields['cover_fees_enabled'];
+	$cover_fees_percentage   = ( ! isset( $donfields['cover_fees_percentage'] ) ) ? '2.9' : $donfields['cover_fees_percentage'];
+	$cover_fees_flat         = ( ! isset( $donfields['cover_fees_flat'] ) ) ? '0.30' : $donfields['cover_fees_flat'];
+	$reminder_interval       = ( ! isset( $donfields['reminder_interval'] ) ) ? 'none' : $donfields['reminder_interval'];
+	$email_template_override = ( ! isset( $donfields['email_template_override'] ) ) ? '' : $donfields['email_template_override'];
 	if ( ! empty( $donations ) ) {
 		$section_visibility = 'visible';
 		$section_activated  = 'true';
@@ -45,6 +54,12 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 						<input type="checkbox" id="donations_only" name="donations_only" value="1" <?php checked( $donations_only, '1' ); ?> /> <label for="donations_only"><?php _e( 'Check to have existing members NOT switched to this level at checkout.', 'pmpro-donations' ); ?></label>
 					</td>
 				</tr>
+				<tr id="allow_guest_donations_row" <?php if ( empty( $donations_only ) ) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top"><label for="allow_guest_donations"><?php esc_html_e( 'Allow Guest Donations:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="checkbox" id="allow_guest_donations" name="allow_guest_donations" value="1" <?php checked( $allow_guest_donations, '1' ); ?> /> <label for="allow_guest_donations"><?php esc_html_e( 'Allow non-logged-in visitors to donate without creating an account.', 'pmpro-donations' ); ?></label>
+					</td>
+				</tr>
 				<tr>
 					<th scope="row" valign="top"><label for="donation_min_price"><?php _e( 'Min Amount:', 'pmpro-donations' ); ?></label></th>
 					<td>
@@ -63,6 +78,15 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 						<input type="text" id="dropdown_prices" name="dropdown_prices" size="60" value="<?php echo esc_attr( $dropdown_prices ); ?>" /><br /><small><?php _e( "Enter numbers separated by commas to popuplate a dropdown with suggested prices. Include 'other' (all lowercase) in the list to allow users to enter their own amount.", 'pmpro-donations' ); ?></small>
 					</td>
 				</tr>
+				<tr id="display_mode_row" <?php if ( empty( $dropdown_prices ) ) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top"><label><?php esc_html_e( 'Display Mode:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<label><input type="radio" name="display_mode" value="buttons" <?php checked( $display_mode, 'buttons' ); ?> /> <?php esc_html_e( 'Buttons', 'pmpro-donations' ); ?></label>
+						&nbsp;&nbsp;
+						<label><input type="radio" name="display_mode" value="dropdown" <?php checked( $display_mode, 'dropdown' ); ?> /> <?php esc_html_e( 'Dropdown', 'pmpro-donations' ); ?></label>
+						<br /><small><?php esc_html_e( 'Choose how donation amounts are displayed at checkout. Buttons show large, clickable tiles. Dropdown shows a classic select menu.', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
 				<tr>
 					<th scope="row" valign="top"><label for="donations_text"><?php _e( 'Help Text:', 'pmpro-donations' ); ?></label></th>
 					<td>
@@ -77,6 +101,58 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
             <br /><small><?php esc_html_e( 'If not blank, this text will be shown after the default confirmation text on the membership checkout confirmation page.', 'pmpro-donations' ); ?></small>
           </td>
         </tr>
+				<tr>
+					<th scope="row" valign="top"><label for="donation_note_enabled"><?php esc_html_e( 'Enable Donation Note:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="checkbox" id="donation_note_enabled" name="donation_note_enabled" value="1" <?php checked( $donation_note_enabled, '1' ); ?> /> <label for="donation_note_enabled"><?php esc_html_e( 'Show a text field at checkout for donors to add a note.', 'pmpro-donations' ); ?></label>
+					</td>
+				</tr>
+				<tr id="donation_note_label_row" <?php if ( empty( $donation_note_enabled ) ) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top"><label for="donation_note_label"><?php esc_html_e( 'Donation Note Label:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="text" id="donation_note_label" name="donation_note_label" size="40" value="<?php echo esc_attr( $donation_note_label ); ?>" />
+						<br /><small><?php esc_html_e( 'Custom label for the donation note field. Defaults to "Donation Note" if blank.', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top"><label for="cover_fees_enabled"><?php esc_html_e( 'Enable Cover Fees:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="checkbox" id="cover_fees_enabled" name="cover_fees_enabled" value="1" <?php checked( $cover_fees_enabled, '1' ); ?> /> <label for="cover_fees_enabled"><?php esc_html_e( 'Show a checkbox at checkout for donors to cover processing fees.', 'pmpro-donations' ); ?></label>
+					</td>
+				</tr>
+				<tr id="cover_fees_percentage_row" <?php if ( empty( $cover_fees_enabled ) ) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top"><label for="cover_fees_percentage"><?php esc_html_e( 'Fee Percentage:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="text" id="cover_fees_percentage" name="cover_fees_percentage" size="10" value="<?php echo esc_attr( $cover_fees_percentage ); ?>" /> %
+						<br /><small><?php esc_html_e( 'The payment gateway percentage fee (e.g. 2.9 for Stripe).', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
+				<tr id="cover_fees_flat_row" <?php if ( empty( $cover_fees_enabled ) ) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top"><label for="cover_fees_flat"><?php esc_html_e( 'Fee Flat Amount:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<?php echo $pmpro_currency_symbol; ?><input type="text" id="cover_fees_flat" name="cover_fees_flat" size="10" value="<?php echo esc_attr( $cover_fees_flat ); ?>" />
+						<br /><small><?php esc_html_e( 'The payment gateway flat fee per transaction (e.g. 0.30 for Stripe).', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top"><label for="reminder_interval"><?php esc_html_e( 'Donation Reminder:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<select id="reminder_interval" name="reminder_interval">
+							<option value="none" <?php selected( $reminder_interval, 'none' ); ?>><?php esc_html_e( 'None', 'pmpro-donations' ); ?></option>
+							<option value="monthly" <?php selected( $reminder_interval, 'monthly' ); ?>><?php esc_html_e( 'Monthly', 'pmpro-donations' ); ?></option>
+							<option value="quarterly" <?php selected( $reminder_interval, 'quarterly' ); ?>><?php esc_html_e( 'Quarterly', 'pmpro-donations' ); ?></option>
+							<option value="annually" <?php selected( $reminder_interval, 'annually' ); ?>><?php esc_html_e( 'Annually', 'pmpro-donations' ); ?></option>
+						</select>
+						<br /><small><?php esc_html_e( 'Send periodic reminder emails to members encouraging them to donate again. Members can opt out from the email.', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top"><label for="email_template_override"><?php esc_html_e( 'Email Template Override:', 'pmpro-donations' ); ?></label></th>
+					<td>
+						<input type="text" id="email_template_override" name="email_template_override" size="40" value="<?php echo esc_attr( $email_template_override ); ?>" />
+						<br /><small><?php esc_html_e( 'Enter a custom email template name to use for checkout emails on this level (e.g. "donation_checkout"). Leave blank for the default checkout email. Admin emails will use this name with "_admin" appended. Compatible with the Email Templates add-on.', 'pmpro-donations' ); ?></small>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 	</div>
@@ -100,6 +176,60 @@ function pmprodon_pmpro_membership_level_after_other_settings() {
 		$('#donations').on('change', function() {
 			toggleDonFields();
 		});
+
+		//toggle guest donations row based on donations_only checkbox
+		const toggleGuestDonations = () => {
+			if($('#donations_only').is(':checked')) {
+				$('#allow_guest_donations_row').show();
+			} else {
+				$('#allow_guest_donations_row').hide();
+			}
+		};
+		toggleGuestDonations();
+		$('#donations_only').on('change', function() {
+			toggleGuestDonations();
+		});
+
+		//toggle display mode row based on dropdown prices
+		const toggleDisplayMode = () => {
+			if($('#dropdown_prices').val().trim() !== '') {
+				$('#display_mode_row').show();
+			} else {
+				$('#display_mode_row').hide();
+			}
+		};
+		toggleDisplayMode();
+		$('#dropdown_prices').on('input', function() {
+			toggleDisplayMode();
+		});
+
+		//toggle donation note label row based on checkbox
+		const toggleNoteLabel = () => {
+			if($('#donation_note_enabled').is(':checked')) {
+				$('#donation_note_label_row').show();
+			} else {
+				$('#donation_note_label_row').hide();
+			}
+		};
+		toggleNoteLabel();
+		$('#donation_note_enabled').on('change', function() {
+			toggleNoteLabel();
+		});
+
+		//toggle cover fees fields based on checkbox
+		const toggleCoverFees = () => {
+			if($('#cover_fees_enabled').is(':checked')) {
+				$('#cover_fees_percentage_row').show();
+				$('#cover_fees_flat_row').show();
+			} else {
+				$('#cover_fees_percentage_row').hide();
+				$('#cover_fees_flat_row').hide();
+			}
+		};
+		toggleCoverFees();
+		$('#cover_fees_enabled').on('change', function() {
+			toggleCoverFees();
+		});
 	});
 </script>
 <?php
@@ -120,21 +250,59 @@ function pmprodon_pmpro_save_membership_level( $level_id ) {
 	} else {
 		$donations_only = 0;
 	}
+	if ( ! empty( $_REQUEST['allow_guest_donations'] ) ) {
+		$allow_guest_donations = 1;
+	} else {
+		$allow_guest_donations = 0;
+	}
 	$min_price	          = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_min_price'] );
 	$max_price	          = preg_replace( '[^0-9\.]', '', $_REQUEST['donation_max_price'] );
 	$text	              = wp_kses_post( wp_unslash( $_REQUEST['donations_text'] ) );
 	$confirmation_message = wp_kses_post( wp_unslash( $_REQUEST['confirmation_message'] ) );
 	$dropdown_prices      = sanitize_text_field( $_REQUEST['dropdown_prices'] );
+	$display_mode         = isset( $_REQUEST['display_mode'] ) && $_REQUEST['display_mode'] === 'buttons' ? 'buttons' : 'dropdown';
+
+	if ( ! empty( $_REQUEST['donation_note_enabled'] ) ) {
+		$donation_note_enabled = 1;
+	} else {
+		$donation_note_enabled = 0;
+	}
+	$donation_note_label = isset( $_REQUEST['donation_note_label'] ) ? sanitize_text_field( $_REQUEST['donation_note_label'] ) : '';
+
+	if ( ! empty( $_REQUEST['cover_fees_enabled'] ) ) {
+		$cover_fees_enabled = 1;
+	} else {
+		$cover_fees_enabled = 0;
+	}
+	$cover_fees_percentage = isset( $_REQUEST['cover_fees_percentage'] ) ? sanitize_text_field( $_REQUEST['cover_fees_percentage'] ) : '2.9';
+	$cover_fees_flat       = isset( $_REQUEST['cover_fees_flat'] ) ? sanitize_text_field( $_REQUEST['cover_fees_flat'] ) : '0.30';
+
+	$valid_intervals    = array( 'none', 'monthly', 'quarterly', 'annually' );
+	$reminder_interval  = isset( $_REQUEST['reminder_interval'] ) ? sanitize_text_field( $_REQUEST['reminder_interval'] ) : 'none';
+	if ( ! in_array( $reminder_interval, $valid_intervals, true ) ) {
+		$reminder_interval = 'none';
+	}
+
+	$email_template_override = isset( $_REQUEST['email_template_override'] ) ? sanitize_text_field( $_REQUEST['email_template_override'] ) : '';
 
 	update_option(
 		'pmprodon_' . $level_id, array(
-			'donations'       => $donations,
-			'donations_only'  => $donations_only,
-			'min_price'       => $min_price,
-			'max_price'       => $max_price,
-			'text'            => $text,
-			'dropdown_prices' => $dropdown_prices,
-			'confirmation_message' => $confirmation_message,
+			'donations'                => $donations,
+			'donations_only'           => $donations_only,
+			'allow_guest_donations'    => $allow_guest_donations,
+			'min_price'                => $min_price,
+			'max_price'                => $max_price,
+			'dropdown_prices'          => $dropdown_prices,
+			'display_mode'             => $display_mode,
+			'text'                     => $text,
+			'confirmation_message'     => $confirmation_message,
+			'donation_note_enabled'    => $donation_note_enabled,
+			'donation_note_label'      => $donation_note_label,
+			'cover_fees_enabled'       => $cover_fees_enabled,
+			'cover_fees_percentage'    => $cover_fees_percentage,
+			'cover_fees_flat'          => $cover_fees_flat,
+			'reminder_interval'        => $reminder_interval,
+			'email_template_override'  => $email_template_override,
 		)
 	);
 }

--- a/includes/reminders.php
+++ b/includes/reminders.php
@@ -177,67 +177,76 @@ function pmprodon_process_donation_reminders() {
 		$interval_seconds = $level_data['interval_seconds'];
 		$level            = $level_data['level'];
 
-		// Get active members on this level.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$members = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT DISTINCT mu.user_id
-				FROM {$wpdb->pmpro_memberships_users} mu
-				WHERE mu.membership_id = %d
-				AND mu.status = 'active'
-				LIMIT 500",
-				$level_id
-			)
-		);
+		// Process active members on this level in deterministic batches.
+		$last_user_id = 0;
+		$batch_size   = 500;
+		do {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$members = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DISTINCT mu.user_id
+					FROM {$wpdb->pmpro_memberships_users} mu
+					WHERE mu.membership_id = %d
+					AND mu.status = 'active'
+					AND mu.user_id > %d
+					ORDER BY mu.user_id ASC
+					LIMIT %d",
+					$level_id,
+					$last_user_id,
+					$batch_size
+				)
+			);
 
-		if ( empty( $members ) ) {
-			continue;
-		}
-
-		foreach ( $members as $member ) {
-			$user_id = intval( $member->user_id );
-
-			// Skip guest donors.
-			$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
-			if ( ! empty( $is_guest ) ) {
-				continue;
+			if ( empty( $members ) ) {
+				break;
 			}
 
-			// Skip opted-out users.
-			$opted_out = get_user_meta( $user_id, 'pmprodon_reminder_optout', true );
-			if ( ! empty( $opted_out ) ) {
-				continue;
-			}
+			foreach ( $members as $member ) {
+				$user_id = intval( $member->user_id );
+				$last_user_id = max( $last_user_id, $user_id );
 
-			// Check last donation date.
-			$last_donation = get_user_meta( $user_id, 'pmprodon_last_donation_date', true );
-			if ( empty( $last_donation ) ) {
-				// No donation date recorded — skip, since we only remind past donors.
-				continue;
-			}
-
-			$time_since_donation = $now - intval( $last_donation );
-			if ( $time_since_donation < $interval_seconds ) {
-				// Not yet due for a reminder.
-				continue;
-			}
-
-			// Check last reminder sent timestamp.
-			$last_reminder = get_user_meta( $user_id, 'pmprodon_last_reminder_sent', true );
-			if ( ! empty( $last_reminder ) ) {
-				$time_since_reminder = $now - intval( $last_reminder );
-				if ( $time_since_reminder < $interval_seconds ) {
-					// Already sent a reminder within this interval.
+				// Skip guest donors.
+				$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
+				if ( ! empty( $is_guest ) ) {
 					continue;
 				}
-			}
 
-			// Send the reminder email.
-			$sent = pmprodon_send_reminder_email( $user_id, $level );
-			if ( $sent ) {
-				update_user_meta( $user_id, 'pmprodon_last_reminder_sent', $now );
+				// Skip opted-out users.
+				$opted_out = get_user_meta( $user_id, 'pmprodon_reminder_optout', true );
+				if ( ! empty( $opted_out ) ) {
+					continue;
+				}
+
+				// Check last donation date.
+				$last_donation = get_user_meta( $user_id, 'pmprodon_last_donation_date', true );
+				if ( empty( $last_donation ) ) {
+					// No donation date recorded — skip, since we only remind past donors.
+					continue;
+				}
+
+				$time_since_donation = $now - intval( $last_donation );
+				if ( $time_since_donation < $interval_seconds ) {
+					// Not yet due for a reminder.
+					continue;
+				}
+
+				// Check last reminder sent timestamp.
+				$last_reminder = get_user_meta( $user_id, 'pmprodon_last_reminder_sent', true );
+				if ( ! empty( $last_reminder ) ) {
+					$time_since_reminder = $now - intval( $last_reminder );
+					if ( $time_since_reminder < $interval_seconds ) {
+						// Already sent a reminder within this interval.
+						continue;
+					}
+				}
+
+				// Send the reminder email.
+				$sent = pmprodon_send_reminder_email( $user_id, $level );
+				if ( $sent ) {
+					update_user_meta( $user_id, 'pmprodon_last_reminder_sent', $now );
+				}
 			}
-		}
+		} while ( count( $members ) === $batch_size );
 	}
 }
 add_action( 'pmprodon_donation_reminders_cron', 'pmprodon_process_donation_reminders' );

--- a/includes/reminders.php
+++ b/includes/reminders.php
@@ -1,0 +1,394 @@
+<?php
+/**
+ * Donation Reminder Emails.
+ *
+ * Handles scheduling and sending periodic donation reminder emails
+ * to members on levels with reminders enabled, and provides an
+ * opt-out mechanism via secure tokenized URLs.
+ *
+ * @since 2.3
+ */
+
+/**
+ * Map reminder interval names to their duration in seconds.
+ *
+ * @since 2.3
+ *
+ * @param string $interval The interval name (monthly, quarterly, annually).
+ * @return int Number of seconds for the interval, or 0 if invalid.
+ */
+function pmprodon_get_interval_seconds( $interval ) {
+	$intervals = array(
+		'monthly'   => 30 * DAY_IN_SECONDS,
+		'quarterly' => 90 * DAY_IN_SECONDS,
+		'annually'  => 365 * DAY_IN_SECONDS,
+	);
+
+	return isset( $intervals[ $interval ] ) ? $intervals[ $interval ] : 0;
+}
+
+/**
+ * Generate a secure opt-out token for a user.
+ *
+ * Uses wp_hash() with the user ID and a static salt to produce
+ * an unforgeable, deterministic token.
+ *
+ * @since 2.3
+ *
+ * @param int $user_id The user ID.
+ * @return string The opt-out token.
+ */
+function pmprodon_get_optout_token( $user_id ) {
+	return wp_hash( 'pmprodon_optout_' . intval( $user_id ) );
+}
+
+/**
+ * Build the opt-out URL for a user.
+ *
+ * @since 2.3
+ *
+ * @param int $user_id The user ID.
+ * @return string The full opt-out URL.
+ */
+function pmprodon_get_optout_url( $user_id ) {
+	return add_query_arg(
+		array(
+			'pmprodon_optout' => '1',
+			'uid'             => intval( $user_id ),
+			'token'           => pmprodon_get_optout_token( $user_id ),
+		),
+		home_url()
+	);
+}
+
+/**
+ * Handle the opt-out request on init.
+ *
+ * Validates the token, sets the opt-out user meta, and redirects
+ * to the home page with a success message stored in a transient.
+ *
+ * @since 2.3
+ */
+function pmprodon_handle_optout() {
+	if ( empty( $_GET['pmprodon_optout'] ) || $_GET['pmprodon_optout'] !== '1' ) {
+		return;
+	}
+
+	$user_id = isset( $_GET['uid'] ) ? intval( $_GET['uid'] ) : 0;
+	$token   = isset( $_GET['token'] ) ? sanitize_text_field( $_GET['token'] ) : '';
+
+	if ( $user_id <= 0 || empty( $token ) ) {
+		return;
+	}
+
+	// Validate the token.
+	$expected_token = pmprodon_get_optout_token( $user_id );
+	if ( ! hash_equals( $expected_token, $token ) ) {
+		return;
+	}
+
+	// Verify the user exists.
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return;
+	}
+
+	// Set opt-out.
+	update_user_meta( $user_id, 'pmprodon_reminder_optout', 1 );
+
+	// Store a transient for a success message on redirect.
+	set_transient( 'pmprodon_optout_success_' . $user_id, true, 60 );
+
+	// Redirect to home with a clean URL.
+	wp_safe_redirect( add_query_arg( 'pmprodon_opted_out', '1', home_url() ) );
+	exit;
+}
+add_action( 'init', 'pmprodon_handle_optout' );
+
+/**
+ * Display a notice after successful opt-out.
+ *
+ * @since 2.3
+ */
+function pmprodon_optout_notice() {
+	if ( empty( $_GET['pmprodon_opted_out'] ) ) {
+		return;
+	}
+	?>
+	<div style="max-width: 600px; margin: 40px auto; padding: 20px; background: #fff; border: 1px solid #ccd0d4; border-radius: 4px; text-align: center;">
+		<p style="font-size: 16px; color: #1e1e1e;">
+			<?php esc_html_e( 'You have been successfully unsubscribed from donation reminder emails.', 'pmpro-donations' ); ?>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'wp_footer', 'pmprodon_optout_notice' );
+
+/**
+ * Cron callback: process donation reminder emails.
+ *
+ * Queries all membership levels with a reminder interval configured,
+ * finds members due for a reminder, and sends the email. Skips
+ * opted-out users and guest donors.
+ *
+ * @since 2.3
+ */
+function pmprodon_process_donation_reminders() {
+	global $wpdb;
+
+	// Bail early if PMPro is not active.
+	if ( ! function_exists( 'pmpro_getAllLevels' ) ) {
+		return;
+	}
+
+	$all_levels = pmpro_getAllLevels( true, true );
+	if ( empty( $all_levels ) ) {
+		return;
+	}
+
+	// Collect levels with reminders enabled.
+	$reminder_levels = array();
+	foreach ( $all_levels as $level ) {
+		$settings = pmprodon_get_level_settings( $level->id );
+		if ( empty( $settings['donations'] ) ) {
+			continue;
+		}
+		if ( empty( $settings['reminder_interval'] ) || $settings['reminder_interval'] === 'none' ) {
+			continue;
+		}
+		$interval_seconds = pmprodon_get_interval_seconds( $settings['reminder_interval'] );
+		if ( $interval_seconds <= 0 ) {
+			continue;
+		}
+		$reminder_levels[ $level->id ] = array(
+			'level'            => $level,
+			'interval_seconds' => $interval_seconds,
+		);
+	}
+
+	if ( empty( $reminder_levels ) ) {
+		return;
+	}
+
+	$now = current_time( 'timestamp' );
+
+	// Process each level.
+	foreach ( $reminder_levels as $level_id => $level_data ) {
+		$interval_seconds = $level_data['interval_seconds'];
+		$level            = $level_data['level'];
+
+		// Get active members on this level.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$members = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT mu.user_id
+				FROM {$wpdb->pmpro_memberships_users} mu
+				WHERE mu.membership_id = %d
+				AND mu.status = 'active'
+				LIMIT 500",
+				$level_id
+			)
+		);
+
+		if ( empty( $members ) ) {
+			continue;
+		}
+
+		foreach ( $members as $member ) {
+			$user_id = intval( $member->user_id );
+
+			// Skip guest donors.
+			$is_guest = get_user_meta( $user_id, 'pmprodon_is_guest_donor', true );
+			if ( ! empty( $is_guest ) ) {
+				continue;
+			}
+
+			// Skip opted-out users.
+			$opted_out = get_user_meta( $user_id, 'pmprodon_reminder_optout', true );
+			if ( ! empty( $opted_out ) ) {
+				continue;
+			}
+
+			// Check last donation date.
+			$last_donation = get_user_meta( $user_id, 'pmprodon_last_donation_date', true );
+			if ( empty( $last_donation ) ) {
+				// No donation date recorded — skip, since we only remind past donors.
+				continue;
+			}
+
+			$time_since_donation = $now - intval( $last_donation );
+			if ( $time_since_donation < $interval_seconds ) {
+				// Not yet due for a reminder.
+				continue;
+			}
+
+			// Check last reminder sent timestamp.
+			$last_reminder = get_user_meta( $user_id, 'pmprodon_last_reminder_sent', true );
+			if ( ! empty( $last_reminder ) ) {
+				$time_since_reminder = $now - intval( $last_reminder );
+				if ( $time_since_reminder < $interval_seconds ) {
+					// Already sent a reminder within this interval.
+					continue;
+				}
+			}
+
+			// Send the reminder email.
+			$sent = pmprodon_send_reminder_email( $user_id, $level );
+			if ( $sent ) {
+				update_user_meta( $user_id, 'pmprodon_last_reminder_sent', $now );
+			}
+		}
+	}
+}
+add_action( 'pmprodon_donation_reminders_cron', 'pmprodon_process_donation_reminders' );
+
+/**
+ * Send a donation reminder email to a user.
+ *
+ * Uses PMPro's PMProEmail class to send the email, following
+ * the same patterns used for checkout emails.
+ *
+ * @since 2.3
+ *
+ * @param int    $user_id The user ID.
+ * @param object $level   The membership level object.
+ * @return bool Whether the email was sent successfully.
+ */
+function pmprodon_send_reminder_email( $user_id, $level ) {
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return false;
+	}
+
+	// Build the donation checkout URL.
+	if ( function_exists( 'pmpro_url' ) ) {
+		$checkout_url = pmpro_url( 'checkout', '?level=' . intval( $level->id ) );
+	} else {
+		$checkout_url = home_url();
+	}
+
+	$optout_url = pmprodon_get_optout_url( $user_id );
+
+	// Get the site name.
+	$sitename = get_bloginfo( 'name' );
+
+	// Build the display name.
+	$display_name = $user->display_name;
+	if ( empty( $display_name ) ) {
+		$display_name = $user->user_login;
+	}
+
+	// Use PMPro's email class if available.
+	if ( class_exists( 'PMProEmail' ) ) {
+		$email = new PMProEmail();
+
+		$email->email    = $user->user_email;
+		$email->subject  = sprintf(
+			/* translators: %s: site name */
+			__( 'Donation Reminder from %s', 'pmpro-donations' ),
+			$sitename
+		);
+		$email->template = 'pmprodon_donation_reminder';
+
+		// Build email body.
+		$body  = '<p>' . sprintf(
+			/* translators: %s: member display name */
+			esc_html__( 'Hi %s,', 'pmpro-donations' ),
+			esc_html( $display_name )
+		) . '</p>';
+		$body .= '<p>' . sprintf(
+			/* translators: %s: level name */
+			esc_html__( 'Thank you for your past donations to %s. We wanted to reach out and let you know that your support makes a real difference.', 'pmpro-donations' ),
+			esc_html( $level->name )
+		) . '</p>';
+		$body .= '<p>' . sprintf(
+			/* translators: %s: donation checkout URL */
+			__( 'If you would like to make another donation, you can do so here: %s', 'pmpro-donations' ),
+			'<a href="' . esc_url( $checkout_url ) . '">' . esc_html( $checkout_url ) . '</a>'
+		) . '</p>';
+		$body .= '<p>' . esc_html__( 'Thank you for your generosity!', 'pmpro-donations' ) . '</p>';
+		$body .= '<hr />';
+		$body .= '<p><small>' . sprintf(
+			/* translators: %s: opt-out URL */
+			__( 'If you no longer wish to receive donation reminders, you can %s.', 'pmpro-donations' ),
+			'<a href="' . esc_url( $optout_url ) . '">' . esc_html__( 'unsubscribe here', 'pmpro-donations' ) . '</a>'
+		) . '</small></p>';
+
+		$email->body = $body;
+
+		// Set email data for PMPro template variables.
+		$email->data = array(
+			'subject'        => $email->subject,
+			'name'           => $display_name,
+			'display_name'   => $display_name,
+			'user_login'     => $user->user_login,
+			'sitename'       => $sitename,
+			'siteemail'      => get_bloginfo( 'admin_email' ),
+			'checkout_link'  => $checkout_url,
+			'optout_link'    => $optout_url,
+			'login_link'     => wp_login_url(),
+			'enddate'        => '',
+			'membership_id'  => $level->id,
+			'membership_level_name' => $level->name,
+		);
+
+		return $email->sendEmail();
+	}
+
+	// Fallback: use wp_mail directly if PMProEmail is not available.
+	$subject = sprintf(
+		/* translators: %s: site name */
+		__( 'Donation Reminder from %s', 'pmpro-donations' ),
+		$sitename
+	);
+
+	$message  = sprintf(
+		/* translators: %s: member display name */
+		__( 'Hi %s,', 'pmpro-donations' ),
+		$display_name
+	) . "\n\n";
+	$message .= sprintf(
+		/* translators: %s: level name */
+		__( 'Thank you for your past donations to %s. We wanted to reach out and let you know that your support makes a real difference.', 'pmpro-donations' ),
+		$level->name
+	) . "\n\n";
+	$message .= sprintf(
+		/* translators: %s: donation checkout URL */
+		__( 'Make another donation: %s', 'pmpro-donations' ),
+		$checkout_url
+	) . "\n\n";
+	$message .= __( 'Thank you for your generosity!', 'pmpro-donations' ) . "\n\n";
+	$message .= '---' . "\n";
+	$message .= sprintf(
+		/* translators: %s: opt-out URL */
+		__( 'Unsubscribe from donation reminders: %s', 'pmpro-donations' ),
+		$optout_url
+	);
+
+	$headers = array( 'Content-Type: text/plain; charset=UTF-8' );
+
+	return wp_mail( $user->user_email, $subject, $message, $headers );
+}
+
+/**
+ * Schedule the daily donation reminders cron event.
+ *
+ * @since 2.3
+ */
+function pmprodon_schedule_reminder_cron() {
+	if ( ! wp_next_scheduled( 'pmprodon_donation_reminders_cron' ) ) {
+		wp_schedule_event( time(), 'daily', 'pmprodon_donation_reminders_cron' );
+	}
+}
+
+/**
+ * Clear the donation reminders cron event.
+ *
+ * @since 2.3
+ */
+function pmprodon_clear_reminder_cron() {
+	$timestamp = wp_next_scheduled( 'pmprodon_donation_reminders_cron' );
+	if ( $timestamp ) {
+		wp_unschedule_event( $timestamp, 'pmprodon_donation_reminders_cron' );
+	}
+}

--- a/includes/reports.php
+++ b/includes/reports.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Donations Report for the PMPro Reports dashboard.
+ *
+ * Provides a report widget, full report page with filtering,
+ * and CSV export of donation data.
+ *
+ * @since 2.3
+ */
+
+/**
+ * Register the Donations report with PMPro's report framework.
+ *
+ * @since 2.3
+ *
+ * @param array $reports Registered reports.
+ * @return array Modified reports array.
+ */
+function pmpro_report_donations_register( $reports ) {
+	$reports['donations'] = __( 'Donations', 'pmpro-donations' );
+	return $reports;
+}
+add_filter( 'pmpro_registered_reports', 'pmpro_report_donations_register' );
+
+/**
+ * Register the AJAX handler for CSV export.
+ *
+ * @since 2.3
+ */
+add_action( 'wp_ajax_pmprodon_donations_csv', 'pmprodon_donations_csv_export' );
+
+/**
+ * Display the Donations report widget on the PMPro Reports dashboard.
+ *
+ * Shows donation count and total revenue for today, this month,
+ * this year, and all time.
+ *
+ * @since 2.3
+ */
+function pmpro_report_donations_widget() {
+	global $wpdb;
+
+	// Build date boundaries.
+	$today_start      = gmdate( 'Y-m-d 00:00:00', current_time( 'timestamp' ) );
+	$month_start      = gmdate( 'Y-m-01 00:00:00', current_time( 'timestamp' ) );
+	$year_start       = gmdate( 'Y-01-01 00:00:00', current_time( 'timestamp' ) );
+
+	// Reusable base query parts.
+	$base_from  = "FROM {$wpdb->pmpro_membership_orders} o";
+	$base_join  = "INNER JOIN {$wpdb->pmpro_membership_ordermeta} om ON o.id = om.pmpro_membership_order_id";
+	$base_where = "WHERE om.meta_key = 'donation_amount' AND CAST( om.meta_value AS DECIMAL(10,2) ) > 0 AND o.status = 'success'";
+
+	// Today.
+	$today_results = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT COUNT(*) AS donation_count, COALESCE( SUM( CAST( om.meta_value AS DECIMAL(10,2) ) ), 0 ) AS donation_total
+			{$base_from} {$base_join} {$base_where} AND o.timestamp >= %s",
+			$today_start
+		)
+	);
+
+	// This month.
+	$month_results = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT COUNT(*) AS donation_count, COALESCE( SUM( CAST( om.meta_value AS DECIMAL(10,2) ) ), 0 ) AS donation_total
+			{$base_from} {$base_join} {$base_where} AND o.timestamp >= %s",
+			$month_start
+		)
+	);
+
+	// This year.
+	$year_results = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT COUNT(*) AS donation_count, COALESCE( SUM( CAST( om.meta_value AS DECIMAL(10,2) ) ), 0 ) AS donation_total
+			{$base_from} {$base_join} {$base_where} AND o.timestamp >= %s",
+			$year_start
+		)
+	);
+
+	// All time.
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- base parts contain no user input.
+	$all_results = $wpdb->get_row(
+		"SELECT COUNT(*) AS donation_count, COALESCE( SUM( CAST( om.meta_value AS DECIMAL(10,2) ) ), 0 ) AS donation_total
+		{$base_from} {$base_join} {$base_where}"
+	);
+
+	?>
+	<span id="pmpro_report_donations" class="pmpro_report-holder">
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Period', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Donations', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Revenue', 'pmpro-donations' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><?php esc_html_e( 'Today', 'pmpro-donations' ); ?></td>
+					<td><?php echo esc_html( intval( $today_results->donation_count ) ); ?></td>
+					<td><?php echo wp_kses_post( pmpro_formatPrice( $today_results->donation_total ) ); ?></td>
+				</tr>
+				<tr>
+					<td><?php esc_html_e( 'This Month', 'pmpro-donations' ); ?></td>
+					<td><?php echo esc_html( intval( $month_results->donation_count ) ); ?></td>
+					<td><?php echo wp_kses_post( pmpro_formatPrice( $month_results->donation_total ) ); ?></td>
+				</tr>
+				<tr>
+					<td><?php esc_html_e( 'This Year', 'pmpro-donations' ); ?></td>
+					<td><?php echo esc_html( intval( $year_results->donation_count ) ); ?></td>
+					<td><?php echo wp_kses_post( pmpro_formatPrice( $year_results->donation_total ) ); ?></td>
+				</tr>
+				<tr>
+					<td><?php esc_html_e( 'All Time', 'pmpro-donations' ); ?></td>
+					<td><?php echo esc_html( intval( $all_results->donation_count ) ); ?></td>
+					<td><?php echo wp_kses_post( pmpro_formatPrice( $all_results->donation_total ) ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+	</span>
+	<?php
+}
+
+/**
+ * Display the full Donations report page.
+ *
+ * Shows a month/year filter, summary stats, and a table of
+ * individual donation entries. Includes a CSV export link.
+ *
+ * @since 2.3
+ */
+function pmpro_report_donations_page() {
+	// Sanitize filter inputs.
+	$month = isset( $_REQUEST['month'] ) ? intval( $_REQUEST['month'] ) : 0;
+	$year  = isset( $_REQUEST['year'] ) ? intval( $_REQUEST['year'] ) : 0;
+
+	// Get filtered donation data.
+	$donations = pmprodon_get_donations_report_data( $month, $year );
+
+	// Calculate summary stats.
+	$total_amount = 0;
+	$count        = count( $donations );
+	foreach ( $donations as $donation ) {
+		$total_amount += (float) $donation->donation_amount;
+	}
+	$average = $count > 0 ? $total_amount / $count : 0;
+
+	// Build the CSV export URL.
+	$csv_url = wp_nonce_url(
+		admin_url( 'admin-ajax.php?action=pmprodon_donations_csv&month=' . intval( $month ) . '&year=' . intval( $year ) ),
+		'pmprodon_donations_csv',
+		'pmprodon_nonce'
+	);
+
+	?>
+	<h1><?php esc_html_e( 'Donations Report', 'pmpro-donations' ); ?></h1>
+
+	<form method="get" action="">
+		<input type="hidden" name="page" value="pmpro-reports" />
+		<input type="hidden" name="report" value="donations" />
+		<?php
+		// Month filter.
+		?>
+		<select name="month">
+			<option value="0"><?php esc_html_e( 'All Months', 'pmpro-donations' ); ?></option>
+			<?php
+			for ( $i = 1; $i <= 12; $i++ ) {
+				$month_label = wp_date( 'F', mktime( 0, 0, 0, $i, 1, 2000 ) );
+				printf(
+					'<option value="%d" %s>%s</option>',
+					intval( $i ),
+					selected( $month, $i, false ),
+					esc_html( $month_label )
+				);
+			}
+			?>
+		</select>
+		<?php
+		// Year filter — show years from the earliest donation to the current year.
+		$current_year = intval( gmdate( 'Y', current_time( 'timestamp' ) ) );
+		$earliest_year = pmprodon_get_earliest_donation_year();
+		?>
+		<select name="year">
+			<option value="0"><?php esc_html_e( 'All Years', 'pmpro-donations' ); ?></option>
+			<?php
+			for ( $y = $current_year; $y >= $earliest_year; $y-- ) {
+				printf(
+					'<option value="%d" %s>%d</option>',
+					intval( $y ),
+					selected( $year, $y, false ),
+					intval( $y )
+				);
+			}
+			?>
+		</select>
+		<input type="submit" class="button" value="<?php esc_attr_e( 'Filter', 'pmpro-donations' ); ?>" />
+		<a href="<?php echo esc_url( $csv_url ); ?>" class="button button-secondary" target="_blank">
+			<?php esc_html_e( 'Export CSV', 'pmpro-donations' ); ?>
+		</a>
+	</form>
+
+	<h2><?php esc_html_e( 'Summary', 'pmpro-donations' ); ?></h2>
+	<table class="wp-list-table widefat fixed striped">
+		<thead>
+			<tr>
+				<th scope="col"><?php esc_html_e( 'Total Donations', 'pmpro-donations' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Count', 'pmpro-donations' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Average', 'pmpro-donations' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><?php echo wp_kses_post( pmpro_formatPrice( $total_amount ) ); ?></td>
+				<td><?php echo esc_html( intval( $count ) ); ?></td>
+				<td><?php echo wp_kses_post( pmpro_formatPrice( $average ) ); ?></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<h2><?php esc_html_e( 'Donation Entries', 'pmpro-donations' ); ?></h2>
+	<?php if ( empty( $donations ) ) { ?>
+		<p><?php esc_html_e( 'No donations found for the selected period.', 'pmpro-donations' ); ?></p>
+	<?php } else { ?>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Order ID', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Member', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Email', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Level', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Donation Amount', 'pmpro-donations' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Date', 'pmpro-donations' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $donations as $entry ) { ?>
+					<tr>
+						<td>
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-orders&order=' . intval( $entry->order_id ) ) ); ?>">
+								<?php echo esc_html( intval( $entry->order_id ) ); ?>
+							</a>
+						</td>
+						<td><?php echo esc_html( $entry->display_name ); ?></td>
+						<td><?php echo esc_html( $entry->user_email ); ?></td>
+						<td><?php echo esc_html( $entry->level_name ); ?></td>
+						<td><?php echo wp_kses_post( pmpro_formatPrice( $entry->donation_amount ) ); ?></td>
+						<td><?php echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $entry->order_date ) ) ); ?></td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+	<?php } ?>
+	<?php
+}
+
+/**
+ * Get the earliest year that has a donation order.
+ *
+ * Used to populate the year filter dropdown. Falls back to the
+ * current year if no donations exist.
+ *
+ * @since 2.3
+ *
+ * @return int The earliest year with a donation.
+ */
+function pmprodon_get_earliest_donation_year() {
+	global $wpdb;
+
+	$earliest = $wpdb->get_var(
+		"SELECT YEAR( MIN( o.timestamp ) )
+		FROM {$wpdb->pmpro_membership_orders} o
+		INNER JOIN {$wpdb->pmpro_membership_ordermeta} om ON o.id = om.pmpro_membership_order_id
+		WHERE om.meta_key = 'donation_amount'
+			AND CAST( om.meta_value AS DECIMAL(10,2) ) > 0
+			AND o.status = 'success'"
+	);
+
+	if ( empty( $earliest ) ) {
+		return intval( gmdate( 'Y', current_time( 'timestamp' ) ) );
+	}
+
+	return intval( $earliest );
+}
+
+/**
+ * Get donation report data with optional month/year filtering.
+ *
+ * Shared query function used by both the report page and CSV export.
+ * Joins orders, order meta, users, and membership levels.
+ *
+ * @since 2.3
+ *
+ * @param int $month Month number (1-12) to filter by, or 0 for all months.
+ * @param int $year  Year to filter by, or 0 for all years.
+ * @return array Array of donation entry objects.
+ */
+function pmprodon_get_donations_report_data( $month = 0, $year = 0 ) {
+	global $wpdb;
+
+	$where_clauses = array(
+		"om.meta_key = 'donation_amount'",
+		"CAST( om.meta_value AS DECIMAL(10,2) ) > 0",
+		"o.status = 'success'",
+	);
+	$prepare_args = array();
+
+	if ( ! empty( $month ) ) {
+		$where_clauses[] = 'MONTH( o.timestamp ) = %d';
+		$prepare_args[]  = intval( $month );
+	}
+
+	if ( ! empty( $year ) ) {
+		$where_clauses[] = 'YEAR( o.timestamp ) = %d';
+		$prepare_args[]  = intval( $year );
+	}
+
+	$where = implode( ' AND ', $where_clauses );
+
+	$query = "SELECT o.id AS order_id,
+			o.user_id,
+			o.membership_id,
+			o.total AS order_total,
+			o.timestamp AS order_date,
+			CAST( om.meta_value AS DECIMAL(10,2) ) AS donation_amount,
+			u.display_name,
+			u.user_email,
+			ml.name AS level_name
+		FROM {$wpdb->pmpro_membership_orders} o
+		INNER JOIN {$wpdb->pmpro_membership_ordermeta} om ON o.id = om.pmpro_membership_order_id
+		LEFT JOIN {$wpdb->users} u ON o.user_id = u.ID
+		LEFT JOIN {$wpdb->pmpro_membership_levels} ml ON o.membership_id = ml.id
+		WHERE {$where}
+		ORDER BY o.timestamp DESC";
+
+	if ( ! empty( $prepare_args ) ) {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query is built from safe table names and static strings; only $prepare_args are user-derived and passed to prepare().
+		$query = $wpdb->prepare( $query, $prepare_args );
+	}
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above when user args exist; unprepared path has no user input.
+	$results = $wpdb->get_results( $query );
+
+	return ! empty( $results ) ? $results : array();
+}
+
+/**
+ * Handle the AJAX request to export donations as CSV.
+ *
+ * Verifies nonce and capability before generating the CSV file.
+ *
+ * @since 2.3
+ */
+function pmprodon_donations_csv_export() {
+	// Capability check.
+	if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_reports' ) ) {
+		wp_die( esc_html__( 'You do not have permission to export this report.', 'pmpro-donations' ) );
+	}
+
+	// Nonce check.
+	check_admin_referer( 'pmprodon_donations_csv', 'pmprodon_nonce' );
+
+	// Get filter params.
+	$month = isset( $_REQUEST['month'] ) ? intval( $_REQUEST['month'] ) : 0;
+	$year  = isset( $_REQUEST['year'] ) ? intval( $_REQUEST['year'] ) : 0;
+
+	// Get the data.
+	$donations = pmprodon_get_donations_report_data( $month, $year );
+
+	// Build filename.
+	$filename_parts = array( 'donations-report' );
+	if ( ! empty( $year ) ) {
+		$filename_parts[] = intval( $year );
+	}
+	if ( ! empty( $month ) ) {
+		$filename_parts[] = str_pad( intval( $month ), 2, '0', STR_PAD_LEFT );
+	}
+	$filename = implode( '-', $filename_parts ) . '.csv';
+
+	// Set headers.
+	header( 'Content-Type: text/csv; charset=' . get_option( 'blog_charset' ) );
+	header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+	header( 'Cache-Control: no-cache, no-store, must-revalidate' );
+	header( 'Pragma: no-cache' );
+	header( 'Expires: 0' );
+
+	// Open output stream.
+	$output = fopen( 'php://output', 'w' );
+
+	// Write header row.
+	fputcsv( $output, array(
+		__( 'Order ID', 'pmpro-donations' ),
+		__( 'User ID', 'pmpro-donations' ),
+		__( 'Member Name', 'pmpro-donations' ),
+		__( 'Email', 'pmpro-donations' ),
+		__( 'Level', 'pmpro-donations' ),
+		__( 'Donation Amount', 'pmpro-donations' ),
+		__( 'Order Total', 'pmpro-donations' ),
+		__( 'Date', 'pmpro-donations' ),
+	) );
+
+	// Write data rows.
+	foreach ( $donations as $entry ) {
+		fputcsv( $output, array(
+			intval( $entry->order_id ),
+			intval( $entry->user_id ),
+			$entry->display_name,
+			$entry->user_email,
+			$entry->level_name,
+			$entry->donation_amount,
+			$entry->order_total,
+			wp_date( 'Y-m-d', strtotime( $entry->order_date ) ),
+		) );
+	}
+
+	fclose( $output );
+	exit;
+}

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Donations
 Plugin URI: https://www.paidmembershipspro.com/add-ons/donations-add-on/
 Description: Allow customers to set an additional donation amount at checkout.
-Version: 2.2
+Version: 2.3
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com/
 Text Domain: pmpro-donations

--- a/pmpro-donations.php
+++ b/pmpro-donations.php
@@ -13,6 +13,7 @@ Domain Path: /languages
 // Definitions
 define( 'PMPRODON_DIR', dirname( __FILE__ ) );
 define( 'PMPRODON_BASENAME', plugin_basename( __FILE__ ) );
+define( 'PMPRODON_VERSION', '2.3' );
 
 // Includes
 require_once( PMPRODON_DIR . '/includes/common.php' );
@@ -20,14 +21,41 @@ require_once( PMPRODON_DIR . '/includes/checkout.php' );
 require_once( PMPRODON_DIR . '/includes/donation-only-level.php' );
 require_once( PMPRODON_DIR . '/includes/level-settings.php' );
 require_once( PMPRODON_DIR . '/includes/admin.php' );
+require_once( PMPRODON_DIR . '/includes/reports.php' );
+require_once( PMPRODON_DIR . '/includes/reminders.php' );
+
+// Schedule cron on activation, clear on deactivation.
+register_activation_hook( __FILE__, 'pmprodon_schedule_reminder_cron' );
+register_deactivation_hook( __FILE__, 'pmprodon_clear_reminder_cron' );
+
+// Also schedule cron on plugins_loaded in case the plugin was updated
+// without a deactivate/activate cycle.
+add_action( 'plugins_loaded', 'pmprodon_schedule_reminder_cron' );
 
 /**
  * Load the languages folder for translations.
  */
 function pmprodon_load_textdomain(){
-	load_plugin_textdomain( 'pmpro-donations', false, basename( dirname( __FILE__ ) ) . '/languages' ); 
+	load_plugin_textdomain( 'pmpro-donations', false, basename( dirname( __FILE__ ) ) . '/languages' );
 }
 add_action( 'plugins_loaded', 'pmprodon_load_textdomain' );
+
+/**
+ * Enqueue frontend styles on the checkout page.
+ *
+ * @since 2.3
+ */
+function pmprodon_enqueue_styles() {
+	if ( function_exists( 'pmpro_is_checkout' ) && pmpro_is_checkout() ) {
+		wp_enqueue_style(
+			'pmpro-donations',
+			plugins_url( 'css/pmpro-donations.css', __FILE__ ),
+			array(),
+			PMPRODON_VERSION
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'pmprodon_enqueue_styles' );
 
 /**
  * Function to add links to the plugin row meta

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, membership, donate, donations, gifts, charity, charities
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 2.2
+Stable tag: 2.3
 
 Allow customers to set an additional donation amount with customized minimum, maxium, and suggested amounts via dropdown at checkout.
 
@@ -24,6 +24,23 @@ This plugin requires Paid Memberships Pro.
 Please post it in the issues section of GitHub and we'll fix it as soon as we can. Thanks for helping. https://github.com/strangerstudios/pmpro-donations/issues
 
 == Changelog ==
+= 2.3 - 2026-02-24 =
+* FEATURE: Added donation amount button tiles UI as an alternative to the dropdown at checkout. #88
+* FEATURE: Added "Cover Processing Fees" checkbox at checkout so donors can cover gateway fees. #89
+* FEATURE: Added guest donations — allow non-logged-in visitors to donate without creating an account. #84
+* FEATURE: Added donation reminder emails on a configurable schedule (monthly, quarterly, annually). #91
+* FEATURE: Added per-level email template overrides compatible with the Email Templates add-on. #93
+* FEATURE: Added donor note text field at checkout with invoice and email integration. #86
+* FEATURE: Added admin donation amount and note fields on the order edit and Add Member pages. #87
+* FEATURE: Added built-in Donations report with filtering by month/year and CSV export. #85
+* ENHANCEMENT: Donation-only level checkout now shows donation-appropriate language throughout. #92
+* ENHANCEMENT: Donation-only confirmation page and emails use donation language instead of membership language. #92
+* BUG FIX: Fixed payment gateways not rendering on free levels with donations enabled. #84
+* BUG FIX: Fixed donation-only level checkout replacing user's existing membership. Now uses PMPro API with level group awareness. #85
+* BUG FIX: Fixed donation amount not being stored when using the Pay by Check gateway. #86
+* BUG FIX: Fixed whitespace in donation amount input causing storage issues. #89
+* BUG FIX: Replaced deprecated `(double)` casts with `(float)` for PHP 8.5 compatibility. #90
+
 = 2.2 - 2025-04-17 =
 * BUG FIX: Fixed an issue where !!donation!! was not correctly being rendered in the email confirmation template. (@becleung, @MaximilianoRicoTabo)
 * BUG FIX: Fixed CSS class selectors for <select> dropdown for the predefined donation amounts. (@kimcoleman)


### PR DESCRIPTION
## Overview

This branch contains all v3.0 work across three phases: bug fixes, enhancements, and ideas meeting features.

## What's Included

### Bug Fixes
- Replace `(double)` casts with `(float)` for PHP 8.5 compatibility
- Enable payment gateways for free levels when donations are present
- Prevent donation-only level from replacing/canceling a user's existing membership — restores previous level post-checkout, cancels donation-only level for new/guest users

### Merged PRs
- PR #85 merged into branch

### Enhancements (TICKETS 04–07)
- Confirmation/thank you language updates for donation-only levels
- Donor notes field at checkout
- Admin donation amount field
- Guest donation support

### Ideas Meeting Features (TICKETS 08–14)
- Donation amount buttons (styled, per-level configurable)
- "Cover processing fees" checkbox with dynamic fee display
- Better donation-only level experience (language, account page, level group awareness)
- Per-level email/confirmation template overrides with `!!donation!!` and `!!donation_note!!` variables

### Hardening
- Revision pass on HomurAI-generated output
- Additional hardening pass on v3.0 donation flows

## How to Test

1. Set up a donation-only membership level
2. Test checkout as a guest, new user, and existing member — confirm existing memberships are preserved post-donation
3. Test donation amount buttons at checkout
4. Test "cover fees" checkbox with Stripe/PayPal
5. Test donor notes field — confirm stored in order meta
6. Confirm per-level email templates fire correctly

## Notes

- This is a draft PR for review — needs QA before merging to `dev`
- Some features (email templates) may overlap with PMPro core email system — worth a second look before shipping
