### PR TITLE
Treat the new pmpro-paypal Add On as a no-billing gateway

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -130,7 +130,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 	</fieldset> <!-- end pmpro_form_fieldset-donation -->
 	<script>
 		//some vars for keeping track of whether or not we show billing
-		var pmpro_gateway_billing = <?php if ( in_array( $gateway, array( 'paypalexpress', 'twocheckout' ) ) !== false ) { echo'false';	} else { echo 'true'; } ?>;
+		var pmpro_gateway_billing = <?php if ( in_array( $gateway, array( 'paypalexpress', 'twocheckout', 'paypal' ) ) !== false ) { echo'false';	} else { echo 'true'; } ?>;
 		var pmpro_pricing_billing = <?php if ( ! pmpro_isLevelFree( $pmpro_level ) ) { echo 'true';	} else { echo 'false'; } ?>;
 		var pmpro_donation_billing = pmpro_pricing_billing;
 
@@ -183,7 +183,7 @@ function pmprodon_pmpro_checkout_after_user_fields() {
 
 			//does the gateway require billing?
 			if(jQuery('input[name=gateway]').length) {
-				var no_billing_gateways = ['paypalexpress', 'twocheckout', 'check', 'paypalstandard'];
+				var no_billing_gateways = ['paypalexpress', 'twocheckout', 'check', 'paypalstandard', 'paypal'];
 				var gateway = jQuery('input[name=gateway]:checked').val();
 				if(no_billing_gateways.indexOf(gateway) > -1)
 					pmpro_gateway_billing = false;


### PR DESCRIPTION
## Summary

The new [pmpro-paypal](https://github.com/strangerstudios/pmpro-paypal) Add On (released as 1.1) registers `paypal` as a checkout gateway and redirects offsite for payment, so no billing address or payment information fields are needed when a member picks PayPal at checkout. Without this change, the donation script's show/hide logic doesn't recognize the `paypal` slug, so it leaves `#pmpro_billing_address_fields` and `#pmpro_payment_information_fields` visible while the user is being redirected offsite.

This adds `paypal` to both:

- the PHP-side initial value of `pmpro_gateway_billing` ([includes/checkout.php:133](includes/checkout.php#L133)), so the page-load state is correct when `?gateway=paypal` is set or when paypal is the primary gateway, and
- the JS `no_billing_gateways` array ([includes/checkout.php:186](includes/checkout.php#L186)), so picking the PayPal radio toggles the fields off correctly at runtime.

The existing `'check' !== gateway` carve-out is unaffected — when the user picks PayPal, we fall into that branch and both billing/payment field groups get hidden, which is the desired behavior for an offsite redirect.

## Test plan

- [ ] Activate Paid Memberships Pro, the pmpro-donations Add On, and the pmpro-paypal Add On (>= 1.1).
- [ ] Configure a paid membership level with the donation field enabled.
- [ ] With Stripe (or any onsite gateway) as the primary gateway and PayPal credentials saved on pmpro-paypal, visit the checkout page.
- [ ] Selecting the **PayPal** radio hides both `#pmpro_billing_address_fields` and `#pmpro_payment_information_fields`. Switching back to the primary radio restores them.
- [ ] Entering a donation amount with PayPal selected does **not** make the billing fields reappear (the donation should still flow through PayPal offsite).
- [ ] With **paypal** as the primary gateway, the donation field still works and billing/payment fields stay hidden on initial load.
- [ ] Existing behavior with `paypalexpress`, `twocheckout`, `check`, and `paypalstandard` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
